### PR TITLE
chore: optimize forest startup script

### DIFF
--- a/forest/start_scripts/forest-init.sh
+++ b/forest/start_scripts/forest-init.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 set -euo pipefail
-sleep 3
 
 # Function to check if DRAND server is healthy
 check_drand_server() {
@@ -16,77 +15,55 @@ check_drand_server() {
 
 sleep 10
 
-FIRST_RUN_FLAG="${FOREST_DATA_DIR}/.initialized"
+DRAND_SERVER="http://10.20.20.21"
 
-if [ ! -f "$FIRST_RUN_FLAG" ]; then
-  echo "forest: first startup – performing one-time setup…"
-  DRAND_SERVER="http://10.20.20.21"
-  
-  echo "Waiting for DRAND server to be ready..."
-  while ! check_drand_server; do
-    sleep 5
-  done
-  echo "DRAND server is ready"
-  
-  json=$(curl -s "$DRAND_SERVER/info")
-  formatted_json=$(jq --arg server "$DRAND_SERVER" '{ servers: [$server], chain_info: { public_key: .public_key, period: .period, genesis_time: .genesis_time, hash: .hash, groupHash: .groupHash }, network_type: "Quicknet" }' <<<"$json")
-  echo "formatted_json: $formatted_json"
-  export FOREST_DRAND_QUICKNET_CONFIG="$formatted_json"
-  export FOREST_F3_BOOTSTRAP_EPOCH=21
-  export FOREST_F3_FINALITY=10
-  NETWORK_NAME=$(jq -r '.NetworkName' "${LOTUS_1_DATA_DIR}/localnet.json")
-  export NETWORK_NAME=$NETWORK_NAME
-  forest --version
-  cp /forest/forest_config.toml.tpl "${FOREST_DATA_DIR}/forest_config.toml"
-  echo "name = \"${NETWORK_NAME}\"" >> "${FOREST_DATA_DIR}/forest_config.toml"
-  forest --genesis "${LOTUS_1_DATA_DIR}/devgen.car" \
-         --config "${FOREST_DATA_DIR}/forest_config.toml" \
-         --save-token "${FOREST_DATA_DIR}/jwt" \
-         --rpc-address ${FOREST_IP}:${FOREST_RPC_PORT} \
-         --p2p-listen-address /ip4/${FOREST_IP}/tcp/${FOREST_P2P_PORT} \
-         --healthcheck-address ${FOREST_IP}:${FOREST_HEALTHZ_RPC_PORT} \
-         --skip-load-actors &
-  sleep 10
-  touch "$FIRST_RUN_FLAG"
-  echo "forest: one-time setup complete."
-else
-  echo "forest: skipping one-time setup."
-  DRAND_SERVER="http://10.20.20.21"
-  
-  echo "Waiting for DRAND server to be ready..."
-  while ! check_drand_server; do
-    sleep 5
-  done
-  echo "DRAND server is ready"
-  
-  json=$(curl -s "$DRAND_SERVER/info")
-  formatted_json=$(jq --arg server "$DRAND_SERVER" '{ servers: [$server], chain_info: { public_key: .public_key, period: .period, genesis_time: .genesis_time, hash: .hash, groupHash: .groupHash }, network_type: "Quicknet" }' <<<"$json")
-  export FOREST_DRAND_QUICKNET_CONFIG="$formatted_json"
-  export FOREST_F3_BOOTSTRAP_EPOCH=20
-  export FOREST_F3_FINALITY=10
-  NETWORK_NAME=$(jq -r '.NetworkName' "${LOTUS_1_DATA_DIR}/localnet.json")
-  export NETWORK_NAME=$NETWORK_NAME
-  echo "forest: starting forest..."
-  forest --genesis "${LOTUS_1_DATA_DIR}/devgen.car" \
-         --config "${FOREST_DATA_DIR}/forest_config.toml" \
-         --save-token "${FOREST_DATA_DIR}/jwt" \
-         --rpc-address ${FOREST_IP}:${FOREST_RPC_PORT} \
-         --p2p-listen-address /ip4/${FOREST_IP}/tcp/${FOREST_P2P_PORT} \
-         --healthcheck-address ${FOREST_IP}:${FOREST_HEALTHZ_RPC_PORT} \
-         --skip-load-actors &
+echo "Waiting for DRAND server to be ready..."
+while ! check_drand_server; do
   sleep 5
-fi
-export TOKEN=$(cat ${FOREST_DATA_DIR}/jwt)
-export FULLNODE_API_INFO=$TOKEN:/ip4/${FOREST_IP}/tcp/${FOREST_RPC_PORT}/http
+done
+echo "DRAND server is ready"
+  
+json=$(curl -s "$DRAND_SERVER/info")
+formatted_json=$(jq --arg server "$DRAND_SERVER" '{ servers: [$server], chain_info: { public_key: .public_key, period: .period, genesis_time: .genesis_time, hash: .hash, groupHash: .groupHash }, network_type: "Quicknet" }' <<<"$json")
+echo "formatted_json: $formatted_json"
+export FOREST_DRAND_QUICKNET_CONFIG="$formatted_json"
+export FOREST_F3_BOOTSTRAP_EPOCH=21
+export FOREST_F3_FINALITY=10
+NETWORK_NAME=$(jq -r '.NetworkName' "${LOTUS_1_DATA_DIR}/localnet.json")
+export NETWORK_NAME=$NETWORK_NAME
+forest --version
+cp /forest/forest_config.toml.tpl "${FOREST_DATA_DIR}/forest_config.toml"
+echo "name = \"${NETWORK_NAME}\"" >> "${FOREST_DATA_DIR}/forest_config.toml"
+forest --genesis "${LOTUS_1_DATA_DIR}/devgen.car" \
+       --config "${FOREST_DATA_DIR}/forest_config.toml" \
+       --save-token "${FOREST_DATA_DIR}/jwt" \
+       --rpc-address "${FOREST_IP}:${FOREST_RPC_PORT}" \
+       --p2p-listen-address "/ip4/${FOREST_IP}/tcp/${FOREST_P2P_PORT}" \
+       --healthcheck-address "${FOREST_IP}:${FOREST_HEALTHZ_RPC_PORT}" \
+       --skip-load-actors &
+
+# Ensure the Forest node API is up before calling other commands
+forest-cli wait-api
+
+# Admin token is required for connection commands and wallet management.
+TOKEN=$(cat "${FOREST_DATA_DIR}/jwt")
+export TOKEN
+FULLNODE_API_INFO=$TOKEN:/ip4/${FOREST_IP}/tcp/${FOREST_RPC_PORT}/http
+export FULLNODE_API_INFO
+
 echo "FULLNODE_API_INFO: $FULLNODE_API_INFO"
 echo "forest: collecting network info…"
+
 forest-cli net listen | head -n1 > "${FOREST_DATA_DIR}/forest-listen-addr"
 echo "forest: connecting to lotus nodes…"
-forest-cli net connect "$(cat ${LOTUS_1_DATA_DIR}/lotus-1-ipv4addr)"
-forest-cli net connect "$(cat ${LOTUS_2_DATA_DIR}/lotus-2-ipv4addr)"
-forest-wallet --remote-wallet import ${LOTUS_1_DATA_DIR}/key 
-forest-wallet --remote-wallet import ${LOTUS_2_DATA_DIR}/key
+forest-cli net connect "$(cat "${LOTUS_1_DATA_DIR}/lotus-1-ipv4addr")"
+forest-cli net connect "$(cat "${LOTUS_2_DATA_DIR}/lotus-2-ipv4addr")"
+forest-wallet --remote-wallet import "${LOTUS_1_DATA_DIR}"/key 
+forest-wallet --remote-wallet import "${LOTUS_2_DATA_DIR}"/key
 
-forest-cli sync wait &
+# Ensure the Forest node is fully synced before proceeding
+forest-cli sync wait
+forest-cli sync status
+forest-cli healthcheck healthy --healthcheck-port "${FOREST_HEALTHZ_RPC_PORT}"
 echo "forest: ready."
 sleep infinity


### PR DESCRIPTION
- reduced some code duplication by eliminating the init branch - they were basically the same, and copying a TOML file with exactly same is cheap anyway,
- I think there was a bug `FOREST_F3_BOOTSTRAP_EPOCH` - in one path it was set to 21, in another to 21? Was it intentional? I assumed not.
- `shellcheck`ed the script
- added healthcheck and made Forest wait for API up and sync before sleeping to infinity. I _think_ it should be fine.
- added some comments

diff between init and not-init for reference

```diff
1c1
<   echo "forest: first startup – performing one-time setup…"
---
>   echo "forest: skipping one-time setup."
12d11
<   echo "formatted_json: $formatted_json"
14c13
<   export FOREST_F3_BOOTSTRAP_EPOCH=21
---
>   export FOREST_F3_BOOTSTRAP_EPOCH=20
18,20c17
<   forest --version
<   cp /forest/forest_config.toml.tpl "${FOREST_DATA_DIR}/forest_config.toml"
<   echo "name = \"${NETWORK_NAME}\"" >> "${FOREST_DATA_DIR}/forest_config.toml"
---
>   echo "forest: starting forest..."
28,30c25
<   sleep 10
<   touch "$FIRST_RUN_FLAG"
<   echo "forest: one-time setup complete."
---
>   sleep 5
```


I hope it works, but I haven't checked. If I can verify it locally, I'd definitely want to.