### PR TITLE
fix: allow importing duplicate keys

### DIFF
--- a/forest/start_scripts/forest-init.sh
+++ b/forest/start_scripts/forest-init.sh
@@ -66,8 +66,8 @@ forest-cli net listen | head -n1 > "${FOREST_DATA_DIR}/forest-listen-addr"
 echo "forest: connecting to lotus nodes…"
 forest-cli net connect "$(cat "${LOTUS_1_DATA_DIR}/lotus-1-ipv4addr")"
 forest-cli net connect "$(cat "${LOTUS_2_DATA_DIR}/lotus-2-ipv4addr")"
-forest-wallet --remote-wallet import "${LOTUS_1_DATA_DIR}"/key 
-forest-wallet --remote-wallet import "${LOTUS_2_DATA_DIR}"/key
+forest-wallet --remote-wallet import "${LOTUS_1_DATA_DIR}"/key  || true
+forest-wallet --remote-wallet import "${LOTUS_2_DATA_DIR}"/key || true
 
 # Ensure the Forest node is fully synced before proceeding
 forest-cli sync wait


### PR DESCRIPTION
The command can fail if run with the same key, so in a scenario with repeated runs over the same keystore using a shared volume. Let's allow it to succeed regardless.