### PR TITLE
fix: speed up local Forest compilation

### DIFF
--- a/forest/Dockerfile
+++ b/forest/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/rust:1.81-bookworm as builder
+FROM docker.io/rust:1.81-bookworm AS builder
 
 # Pin forest to a specific branch
 ARG GIT_COMMIT="main"
@@ -30,14 +30,7 @@ COPY ./forest_config.toml.tpl .
 # RUN git apply ./forest.patch
 COPY libvoidstar.so /usr/local/lib/libvoidstar.so 
 RUN if [ "$LOCAL_BUILD" = "1" ]; then \
-        cargo build --release --bin forest-cli; \
-        cargo build --release --bin forest-tool; \
-        cargo build --release --bin forest-wallet; \
-        cargo build --release --bin forest; \
-        cp /forest/target/release/forest-cli /usr/local/cargo/bin/forest-cli; \
-        cp /forest/target/release/forest-tool /usr/local/cargo/bin/forest-tool; \
-        cp /forest/target/release/forest-wallet /usr/local/cargo/bin/forest-wallet; \
-        cp /forest/target/release/forest /usr/local/cargo/bin/forest; \
+        make install-quick; \
     else \
         # Build forest binaries + Rust instrumentation on main forest binary for code coverage 
         cargo build --release --bin forest-cli && \


### PR DESCRIPTION
On my machine, this speeds up local Forest compilation from ~260s to ~120s. Only local changes, but I recommend looking into the instrumented branch if it's an issue.