### PR TITLE
fix: no skip load actors for Forest

### DIFF
--- a/forest/start_scripts/forest-init.sh
+++ b/forest/start_scripts/forest-init.sh
@@ -43,15 +43,13 @@ forest --genesis "${LOTUS_1_DATA_DIR}/devgen.car" \
        --config "${FOREST_DATA_DIR}/forest_config.toml" \
        --save-token "${FOREST_DATA_DIR}/jwt" \
        --no-healthcheck \
-       --skip-load-actors \
        --exit-after-init
 
 forest --genesis "${LOTUS_1_DATA_DIR}/devgen.car" \
        --config "${FOREST_DATA_DIR}/forest_config.toml" \
        --rpc-address "${FOREST_IP}:${FOREST_RPC_PORT}" \
        --p2p-listen-address "/ip4/${FOREST_IP}/tcp/${FOREST_P2P_PORT}" \
-       --healthcheck-address "${FOREST_IP}:${FOREST_HEALTHZ_RPC_PORT}" \
-       --skip-load-actors &
+       --healthcheck-address "${FOREST_IP}:${FOREST_HEALTHZ_RPC_PORT}" &
 
 # Admin token is required for connection commands and wallet management.
 TOKEN=$(cat "${FOREST_DATA_DIR}/jwt")


### PR DESCRIPTION
Actors are cached in the Dockerfile anyway; there's no need to skip them.

This is caused by https://github.com/ChainSafe/forest/pull/6193, which operates on the bundles without ensuring they are loaded. To be fixed on the Forest side (or we can remove this flag to make things simpler).