### PR TITLE
foc workload fix and adding more robust code

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -111,7 +111,7 @@ services:
       - STRESS_WEIGHT_HEAD_COMPARISON=3 # cross-node chain head match
       - STRESS_WEIGHT_STATE_ROOT=4 # cross-node state root match
       - STRESS_WEIGHT_STATE_AUDIT=5 # full state tree audit
-      - STRESS_WEIGHT_REORG=0 # checks cluster converges correctly after partitioned periods
+      - STRESS_WEIGHT_REORG=1 # checks cluster converges correctly after partitioned periods
       #
       # --- Non-FOC stress vectors ---
       #

--- a/workload/cmd/stress-engine/foc_vectors.go
+++ b/workload/cmd/stress-engine/foc_vectors.go
@@ -307,6 +307,12 @@ func doStepCreateDataSet() {
 		"onChainDataSetID": onChainID,
 	})
 
+	// Cross-verify: the txHash Curio returned should be a successful tx on-chain
+	verifyTxOnChain(txHash, "createDataSet", map[string]any{
+		"clientDataSetId":  clientDataSetId.String(),
+		"onChainDataSetID": onChainID,
+	})
+
 	focStateMu.Lock()
 	focState.ClientDataSetID = clientDataSetId
 	focState.OnChainDataSetID = onChainID
@@ -454,6 +460,13 @@ func DoFOCAddPieces() {
 		"pieceIDs": pieceIDs,
 	})
 
+	// Cross-verify: the txHash Curio returned should be a successful tx on-chain
+	verifyTxOnChain(txHash, "addPieces", map[string]any{
+		"pieceCID":  piece.PieceCID,
+		"pieceIDs":  pieceIDs,
+		"dataSetID": dataSetID,
+	})
+
 	focStateMu.Lock()
 	if len(pieceIDs) > 0 {
 		for _, pid := range pieceIDs {
@@ -513,6 +526,10 @@ func DoFOCMonitorProofSet() {
 
 	log.Printf("[foc-monitor] dataset=%d live=%v activePieces=%s nextChallenge=%s",
 		s.OnChainDataSetID, live, activePieces, nextChallenge)
+
+	// Passive consistency check — detect if on-chain state diverged from
+	// what we're tracking (e.g., due to reorgs corrupting Curio's DB).
+	verifyFOCStateConsistency(s, live, activePieces, nextChallenge)
 }
 
 // DoFOCTransfer performs an ERC-20 USDFC transfer between client and deployer.
@@ -619,8 +636,21 @@ func DoFOCWithdraw() {
 		return
 	}
 
+	// Guard against insolvency: only withdraw from the portion that exceeds
+	// lockup + a safety margin (100 USDFC). The solvency invariant requires
+	// balanceOf(FilecoinPay) >= Σ(funds + lockup), so withdrawing too much
+	// from funds while lockup is non-zero triggers a false-positive violation.
+	lockup := foc.ReadAccountLockup(ctx, node, focCfg.FilPayAddr, focCfg.USDFCAddr, focCfg.ClientEthAddr)
+	safetyMargin := new(big.Int).Mul(big.NewInt(100), big.NewInt(focUSDFCUnit))
+	minKeep := new(big.Int).Add(lockup, safetyMargin)
+	if funds.Cmp(minKeep) <= 0 {
+		log.Printf("[foc-withdraw] funds=%s <= lockup+margin=%s, skipping to preserve solvency", funds, minKeep)
+		return
+	}
+	withdrawable := new(big.Int).Sub(funds, minKeep)
+
 	pct := 1 + rngIntn(5)
-	amount := new(big.Int).Mul(funds, big.NewInt(int64(pct)))
+	amount := new(big.Int).Mul(withdrawable, big.NewInt(int64(pct)))
 	amount.Div(amount, big.NewInt(100))
 	if amount.Sign() == 0 {
 		return
@@ -828,6 +858,216 @@ func DoFOCRetrieveAndVerify() {
 			piece.PieceCID, computedCID, len(data))
 	} else {
 		log.Printf("[foc-retrieve] verified: cid=%s len=%d", piece.PieceCID, len(data))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Passive FOC State Consistency Check
+//
+// Called from DoFOCMonitorProofSet after querying on-chain proofset state.
+// Detects divergence between on-chain state and our tracked state — the kind
+// of corruption caused by Curio's TX-first-then-DB pattern under reorgs.
+//
+// FALSE POSITIVE PREVENTION:
+// - Only asserts when ALL eth_call reads succeeded (non-nil values)
+// - Uses >= for piece count (pieces can be added between snapshot and check)
+// - Uses >= for piece count floor of 0 (deletions can reduce count)
+// - Skips if dataset is not in Ready state (lifecycle transitions are expected)
+// - All data comes from the same node/tipset (no cross-node comparison here;
+//   consensus vectors handle that independently)
+// ---------------------------------------------------------------------------
+
+func verifyFOCStateConsistency(s focRuntime, live bool, activePieces *big.Int, nextChallenge *big.Int) {
+	// Guard: only check when we have complete on-chain data.
+	// If any eth_call failed (returned nil), the node may be mid-reorg or
+	// partitioned — asserting on partial data would be a false positive.
+	if activePieces == nil || nextChallenge == nil {
+		return
+	}
+
+	onChainCount := activePieces.Int64()
+	trackedAdded := int64(len(s.AddedPieces))
+
+	// Safety: the on-chain proofset for the FOC dataset must remain live
+	// (i.e. not deleted or terminated) at all times once the lifecycle
+	// reaches Ready state. A non-live proofset means either:
+	//   (a) Curio's deleteDataSet or terminateService was triggered by a
+	//       reorg-corrupted receipt (TX-first-then-DB vulnerability), or
+	//   (b) a contract bug in PDPVerifier/FWSS caused unexpected termination.
+	// This is the primary safety invariant for FOC: the storage service
+	// must not silently disappear while clients believe data is being stored.
+	assert.Always(live, "FOC proofset remains live: on-chain dataset must not be deleted or terminated while lifecycle is active", map[string]any{
+		"dataSetID":           s.OnChainDataSetID,
+		"on_chain_pieces":     onChainCount,
+		"tracked_added":       trackedAdded,
+		"tracked_uploaded":    len(s.UploadedPieces),
+		"termination_started": s.TerminationInitiated,
+	})
+
+	if !live {
+		log.Printf("[foc-verify] CRITICAL: proofset %d is NOT live!", s.OnChainDataSetID)
+		return
+	}
+
+	// Observability: log piece counts so investigators can correlate
+	// on-chain state vs. what the stress engine tracked. We do NOT
+	// assert strict equality because the deck runs DoFOCAddPieces and
+	// DoFOCDeletePiece concurrently — the on-chain count can legitimately
+	// differ from our tracked count at any point in time.
+	log.Printf("[foc-verify] dataset=%d on_chain_pieces=%d tracked_added=%d",
+		s.OnChainDataSetID, onChainCount, trackedAdded)
+
+	// Liveness: Curio's proving system must eventually schedule a future
+	// challenge epoch for the proofset. A challenge epoch of 0 or stuck
+	// in the past would indicate that Curio's nextProvingPeriod task
+	// stopped advancing — possibly due to a crash, DB corruption from a
+	// reorg, or the proving-deleted-data bug (curio/issues/1039).
+	// We use assert.Sometimes (not Always) because the challenge epoch
+	// can temporarily be in the past during the window between one proof
+	// completing and nextProvingPeriod being called.
+	challengeEpoch := nextChallenge.Int64()
+	if challengeEpoch > 0 {
+		assert.Sometimes(challengeEpoch > 0, "FOC proving system is scheduling challenges: nextChallengeEpoch should be set for active proofsets", map[string]any{
+			"dataSetID":       s.OnChainDataSetID,
+			"challengeEpoch":  challengeEpoch,
+			"on_chain_pieces": onChainCount,
+			"tracked_added":   trackedAdded,
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Payment Pre-flight — keeps escrow funded to prevent solvency violations
+// ---------------------------------------------------------------------------
+
+const (
+	focMinEscrowBalance = 50  // USDFC — trigger top-up below this
+	focTopUpAmount      = 200 // USDFC — amount to deposit on each top-up
+)
+
+// DoFOCPaymentPreflight checks the FilecoinPay escrow balance and deposits
+// more USDFC if it's running low. This prevents the solvency invariant
+// (balanceOf(FilecoinPay) >= Σ funds+lockup) from firing due to test
+// infrastructure underfunding rather than a real contract bug.
+func DoFOCPaymentPreflight() {
+	if focCfg == nil || focCfg.ClientKey == nil || focCfg.USDFCAddr == nil ||
+		focCfg.FilPayAddr == nil || focCfg.ClientEthAddr == nil {
+		return
+	}
+	s := snap()
+	if s.State != focStateReady {
+		return
+	}
+
+	node := focNode()
+
+	// 1. Check FilecoinPay escrow balance
+	escrowFunds := foc.ReadAccountFunds(ctx, node, focCfg.FilPayAddr, focCfg.USDFCAddr, focCfg.ClientEthAddr)
+	minWei := new(big.Int).Mul(big.NewInt(focMinEscrowBalance), big.NewInt(focUSDFCUnit))
+
+	if escrowFunds.Cmp(minWei) >= 0 {
+		debugLog("[foc-preflight] escrow OK: %s", escrowFunds)
+		return
+	}
+
+	log.Printf("[foc-preflight] escrow low (%s), checking ERC-20 wallet...", escrowFunds)
+
+	// 2. Check ERC-20 wallet balance
+	balCalldata := foc.BuildCalldata(foc.SigBalanceOf, foc.EncodeAddress(focCfg.ClientEthAddr))
+	walletBal, err := foc.EthCallUint256(ctx, node, focCfg.USDFCAddr, balCalldata)
+	if err != nil || walletBal == nil {
+		log.Printf("[foc-preflight] wallet balance check failed: %v", err)
+		return
+	}
+
+	topUpWei := new(big.Int).Mul(big.NewInt(focTopUpAmount), big.NewInt(focUSDFCUnit))
+
+	if walletBal.Cmp(topUpWei) < 0 {
+		log.Printf("[foc-preflight] wallet balance too low (%s) for top-up, skipping", walletBal)
+		assert.Sometimes(false, "FOC client has sufficient USDFC for continued operation: "+
+			"wallet balance fell below top-up threshold, settlements may be draining faster than expected",
+			map[string]any{
+				"escrow_balance": escrowFunds.String(),
+				"wallet_balance": walletBal.String(),
+				"top_up_amount":  topUpWei.String(),
+			})
+		return
+	}
+
+	// 3. Deposit into FilecoinPay escrow
+	depositCalldata := foc.BuildCalldata(foc.SigDeposit,
+		foc.EncodeAddress(focCfg.USDFCAddr),
+		foc.EncodeAddress(focCfg.ClientEthAddr),
+		foc.EncodeBigInt(topUpWei),
+	)
+
+	ok := foc.SendEthTxConfirmed(ctx, node, focCfg.ClientKey, focCfg.FilPayAddr, depositCalldata, "foc-preflight-deposit")
+
+	// 4. Verify funds arrived
+	if ok {
+		newFunds := foc.ReadAccountFunds(ctx, node, focCfg.FilPayAddr, focCfg.USDFCAddr, focCfg.ClientEthAddr)
+		log.Printf("[foc-preflight] top-up complete: escrow %s → %s", escrowFunds, newFunds)
+		assert.Sometimes(true, "FOC escrow top-up succeeds when balance is low", map[string]any{
+			"old_escrow": escrowFunds.String(),
+			"new_escrow": newFunds.String(),
+			"deposited":  topUpWei.String(),
+		})
+	} else {
+		log.Printf("[foc-preflight] deposit tx failed — escrow remains at %s", escrowFunds)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Tx Hash Cross-Verification
+// ---------------------------------------------------------------------------
+
+// verifyTxOnChain independently verifies a txHash that Curio reported as
+// confirmed. Called AFTER Curio's polling endpoint confirms the operation
+// (WaitForPieceAddition or WaitForDataSetCreation), so the tx should
+// definitely be mined by this point.
+//
+// This catches the TX-first-then-DB vulnerability: Curio says "confirmed"
+// but the chain tells a different story (especially after reorgs).
+func verifyTxOnChain(txHash string, operation string, details map[string]any) {
+	node := focNode()
+
+	receipt, err := foc.VerifyTxReceipt(ctx, node, txHash)
+	if err != nil {
+		// Node might be mid-reorg or partitioned — don't assert on transient failures
+		log.Printf("[foc-tx-verify] %s: receipt fetch failed for %s: %v", operation, txHash, err)
+		return
+	}
+	if receipt == nil {
+		// Tx not yet visible — possible under heavy load or reorg
+		log.Printf("[foc-tx-verify] %s: no receipt yet for %s (pending?)", operation, txHash)
+		return
+	}
+
+	// If we got a receipt, Curio said the operation succeeded, so the tx MUST
+	// have status=1. A status=0 (reverted) means Curio's DB diverged from
+	// chain reality — exactly the TX-first-then-DB bug we're hunting.
+	txSucceeded := receipt.Status == 1
+
+	mergedDetails := map[string]any{
+		"txHash":      txHash,
+		"operation":   operation,
+		"status":      receipt.Status,
+		"gasUsed":     receipt.GasUsed,
+		"blockNumber": receipt.BlockNumber,
+	}
+	for k, v := range details {
+		mergedDetails[k] = v
+	}
+
+	assert.Always(txSucceeded, "FOC tx hash matches between Curio and chain",
+		mergedDetails)
+
+	if !txSucceeded {
+		log.Printf("[foc-tx-verify] CRITICAL: %s tx %s REVERTED on-chain (status=%d) but Curio reported success!",
+			operation, txHash, receipt.Status)
+	} else {
+		log.Printf("[foc-tx-verify] %s tx %s verified on-chain: status=1 block=%v",
+			operation, txHash, receipt.BlockNumber)
 	}
 }
 

--- a/workload/cmd/stress-engine/main.go
+++ b/workload/cmd/stress-engine/main.go
@@ -124,6 +124,14 @@ func rngChoice[T any](items []T) T {
 }
 
 func pickNode() (string, api.FullNode) {
+	// When FOC is active, bias toward lotus0 (Curio's backend) ~70% of the time.
+	// This ensures stress vectors create contention on the same node Curio uses
+	// for on-chain transactions, eth_call reads, and receipt processing.
+	if focCfg != nil {
+		if n, ok := nodes["lotus0"]; ok && rngIntn(100) < 70 {
+			return "lotus0", n
+		}
+	}
 	name := rngChoice(nodeKeys)
 	return name, nodes[name]
 }
@@ -287,7 +295,20 @@ func buildDeck() {
 	if focCfg == nil {
 		actions = append(actions, stress...)
 	} else {
-		log.Println("[init] FOC active — skipping non-FOC stress vectors (covered by filecoin run)")
+		// Targeted stress vectors that exercise subsystems FOC depends on.
+		// These create state trie churn, gas contention, and reorgs on the
+		// Curio-backing node (lotus0 via pickNode() bias).
+		// Weights are low (1) so FOC lifecycle vectors still dominate the deck.
+		log.Println("[init] FOC active — adding targeted stress vectors for Curio-backing node")
+		focStress := []weightedAction{
+			{"DoStorageSpam", "STRESS_WEIGHT_STORAGE_SPAM", DoStorageSpam, 1},
+			{"DoDeployContracts", "STRESS_WEIGHT_DEPLOY", DoDeployContracts, 1},
+			{"DoContractCall", "STRESS_WEIGHT_CONTRACT_CALL", DoContractCall, 1},
+			{"DoGasWar", "STRESS_WEIGHT_GAS_WAR", DoGasWar, 1},
+			{"DoSelfDestructCycle", "STRESS_WEIGHT_SELFDESTRUCT", DoSelfDestructCycle, 1},
+			{"DoReorgChaos", "STRESS_WEIGHT_REORG", DoReorgChaos, 1},
+		}
+		actions = append(actions, focStress...)
 	}
 
 	// FOC lifecycle vectors — only when FOC profile is active
@@ -303,8 +324,8 @@ func buildDeck() {
 			weightedAction{"DoFOCTransfer", "STRESS_WEIGHT_FOC_TRANSFER", DoFOCTransfer, 1},
 			weightedAction{"DoFOCSettle", "STRESS_WEIGHT_FOC_SETTLE", DoFOCSettle, 1},
 			weightedAction{"DoFOCWithdraw", "STRESS_WEIGHT_FOC_WITHDRAW", DoFOCWithdraw, 1},
-			// Destructive — weight 0 by default (opt-in)
-			weightedAction{"DoFOCDeletePiece", "STRESS_WEIGHT_FOC_DELETE_PIECE", DoFOCDeletePiece, 0},
+			weightedAction{"DoFOCDeletePiece", "STRESS_WEIGHT_FOC_DELETE_PIECE", DoFOCDeletePiece, 1},
+			weightedAction{"DoFOCPaymentPreflight", "STRESS_WEIGHT_FOC_PREFLIGHT", DoFOCPaymentPreflight, 1},
 			weightedAction{"DoFOCDeleteDataSet", "STRESS_WEIGHT_FOC_DELETE_DS", DoFOCDeleteDataSet, 0},
 		)
 	}

--- a/workload/cmd/stress-engine/reorg_vectors.go
+++ b/workload/cmd/stress-engine/reorg_vectors.go
@@ -42,8 +42,20 @@ func DoReorgChaos() {
 		return
 	}
 
-	// Pick a victim node to isolate
-	victimName := rngChoice(nodeKeys)
+	// Pick a victim node to isolate.
+	// When FOC is active, bias toward lotus0 (Curio's backend) 60% of the time.
+	// This tests Curio's zero-reorg-awareness: receipts it read and acted on
+	// become invalid after partition heal, but Curio never re-validates.
+	var victimName string
+	if focCfg != nil {
+		if _, ok := nodes["lotus0"]; ok && rngIntn(100) < 60 {
+			victimName = "lotus0"
+		} else {
+			victimName = rngChoice(nodeKeys)
+		}
+	} else {
+		victimName = rngChoice(nodeKeys)
+	}
 	victim := nodes[victimName]
 
 	// Random number of rapid split-heal cycles: 1-10

--- a/workload/entrypoint/entrypoint.sh
+++ b/workload/entrypoint/entrypoint.sh
@@ -77,7 +77,12 @@ log_info "Launching stress engine..."
 /opt/antithesis/stress-engine &
 STRESS_PID=$!
 
-if [ "${FUZZER_ENABLED:-1}" = "1" ]; then
+# Skip protocol fuzzer in FOC profile — FOC vectors target Curio's
+# application layer, not the libp2p wire protocols the fuzzer attacks.
+# Running both adds noise to the report without finding FOC-relevant bugs.
+if getent hosts filwizard &>/dev/null; then
+    log_info "FOC profile — skipping protocol fuzzer"
+elif [ "${FUZZER_ENABLED:-1}" = "1" ]; then
     log_info "Launching protocol fuzzer..."
     /opt/antithesis/protocol-fuzzer &
     FUZZER_PID=$!

--- a/workload/internal/foc/eth.go
+++ b/workload/internal/foc/eth.go
@@ -2,6 +2,7 @@ package foc
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"math/big"
 	"sync"
@@ -313,4 +314,18 @@ func EncodeUint256(n uint64) []byte {
 	buf[30] = byte(n >> 8)
 	buf[31] = byte(n)
 	return buf
+}
+
+// VerifyTxReceipt fetches a transaction receipt by hash string and returns
+// (receipt, error). Returns (nil, nil) if the tx is not yet mined.
+func VerifyTxReceipt(ctx context.Context, node api.FullNode, txHashStr string) (*ethtypes.EthTxReceipt, error) {
+	hash, err := ethtypes.ParseEthHash(txHashStr)
+	if err != nil {
+		return nil, fmt.Errorf("parse tx hash %q: %w", txHashStr, err)
+	}
+	receipt, err := node.EthGetTransactionReceipt(ctx, hash)
+	if err != nil {
+		return nil, fmt.Errorf("EthGetTransactionReceipt: %w", err)
+	}
+	return receipt, nil
 }


### PR DESCRIPTION
1. Adding preflights to reduce False Positives. 
2. Enable reorg to test FOC boundaries.
3. Stress lotus0 more, since it backs curio for sync and consensus.
4. Enable some non foc tests to test EVM primitives.
