### PR TITLE
restart and crashes fix

### DIFF
--- a/curio/start_scripts/curio-init.sh
+++ b/curio/start_scripts/curio-init.sh
@@ -187,6 +187,13 @@ if [ ! -f $CURIO_REPO_PATH/.init.pdp ]; then
   echo "PDP service setup complete"
 fi
 
+# Source .env.curio on every boot (not just first) so curio has contract addresses after restart
+if [ -f $CURIO_REPO_PATH/.env.curio ]; then
+  echo "Loading contract addresses from .env.curio..."
+  set -a
+  source ${CURIO_REPO_PATH}/.env.curio
+  set +a
+fi
+
 echo Starting curio node ...
 CURIO_FAKE_CPU=5 curio run --nosync --name devnet --layers seal,post,pdp-only,gui
-sleep infinity

--- a/forest/scripts/start-forest.sh
+++ b/forest/scripts/start-forest.sh
@@ -72,6 +72,8 @@ forest --genesis "${SHARED_CONFIGS}/devgen.car" \
        --p2p-listen-address "/ip4/${host_ip}/tcp/${FOREST_P2P_PORT}" \
        --healthcheck-address "${host_ip}:${FOREST_HEALTHZ_RPC_PORT}" &
 
+FOREST_PID=$!
+
 # Admin token is required for connection commands and wallet management.
 export TOKEN=$(cat "${FOREST_DATA_DIR}/jwt")
 export FULLNODE_API_INFO="$TOKEN:/ip4/$host_ip/tcp/${FOREST_RPC_PORT}/http"
@@ -156,4 +158,4 @@ forest-cli healthcheck healthy --healthcheck-port "${FOREST_HEALTHZ_RPC_PORT}"
 
 echo "forest${no}: completed startup"
 
-sleep infinity
+wait $FOREST_PID

--- a/lotus/scripts/start-lotus-miner.sh
+++ b/lotus/scripts/start-lotus-miner.sh
@@ -22,7 +22,8 @@ export CGO_CFLAGS_ALLOW="-D__BLST_PORTABLE__"
 export CGO_CFLAGS="-D__BLST_PORTABLE__"
 
 lotus-miner --version
-lotus wallet import --as-default ${SHARED_CONFIGS}/.genesis-sector-${no}/pre-seal-${LOTUS_MINER_ACTOR_ADDRESS}.key
+lotus wait-api
+lotus wallet import --as-default ${SHARED_CONFIGS}/.genesis-sector-${no}/pre-seal-${LOTUS_MINER_ACTOR_ADDRESS}.key || true
 
 if [ -f "${LOTUS_MINER_PATH}/config.toml" ]; then
     echo "lotus-miner${no}: Repo already exists, skipping init..."

--- a/lotus/scripts/start-lotus.sh
+++ b/lotus/scripts/start-lotus.sh
@@ -68,8 +68,11 @@ if [ "$INIT_MODE" = "true" ]; then
         lotus --repo="${LOTUS_PATH}" daemon --genesis=${SHARED_CONFIGS}/devgen.car --bootstrap=false --config=config.toml&
     fi
 else
-    lotus --repo="${LOTUS_PATH}" daemon --bootstrap=false --config=config.toml&
+    echo "lotus${no}: Restart detected, skipping init..."
+    lotus --repo="${LOTUS_PATH}" daemon --bootstrap=false --config=config.toml &
 fi
+
+LOTUS_PID=$!
 
 lotus --version
 lotus wait-api
@@ -127,4 +130,4 @@ done
 
 echo "lotus${no}: completed startup"
 
-sleep infinity
+wait $LOTUS_PID


### PR DESCRIPTION
1. Adding preflights to reduce False Positives. 
2. Enable reorg to test FOC boundaries.
3. Stress lotus0 more, since it backs curio for sync and consensus.
4. Enable some non foc tests to test EVM primitives.
