### PR TITLE
miner initialization fix. Gives more confidence

### DIFF
--- a/lotus/scripts/start-lotus-miner.sh
+++ b/lotus/scripts/start-lotus-miner.sh
@@ -11,6 +11,9 @@ export LOTUS_PATH="${!lotus_path}"
 lotus_miner_path="LOTUS_MINER_${node_number}_PATH"
 export LOTUS_MINER_PATH="${!lotus_miner_path}"
 
+lotus_miner_api="LOTUS_MINER_${node_number}_API_LISTENADDRESS"
+export LOTUS_API_LISTENADDRESS="${!lotus_miner_api}"
+
 export LOTUS_F3_BOOTSTRAP_EPOCH=21
 export DRAND_CHAIN_INFO=chain_info
 export LOTUS_SKIP_GENESIS_CHECK=${LOTUS_SKIP_GENESIS_CHECK}

--- a/workload/entrypoint/entrypoint.sh
+++ b/workload/entrypoint/entrypoint.sh
@@ -38,7 +38,40 @@ while true; do
     sleep 5
 done
 
-# ── 4. Wait for filwizard if running (FOC profile, auto-detected via DNS) ──
+# ── 4. Wait for all miners to have produced at least one block ──
+log_info "Discovering registered miners via StateListMiners..."
+while true; do
+    MINER_ADDRS=$(curl -sf -m 5 -X POST -H "Content-Type: application/json" \
+        --data '{"jsonrpc":"2.0","method":"Filecoin.StateListMiners","params":[null],"id":1}' \
+        "$RPC_URL" 2>/dev/null | jq -rc '.result // empty' 2>/dev/null)
+    if [ -n "$MINER_ADDRS" ] && [ "$MINER_ADDRS" != "null" ] && [ "$MINER_ADDRS" != "[]" ]; then
+        break
+    fi
+    sleep 3
+done
+MINER_COUNT=$(echo "$MINER_ADDRS" | jq 'length')
+log_info "Found ${MINER_COUNT} miners on-chain: $(echo "$MINER_ADDRS" | jq -r 'join(", ")')"
+
+# Wait for each miner daemon's RPC to respond (requires LOTUS_API_LISTENADDRESS fix)
+MINER_RPC_PORT="${LOTUS_MINER_RPC_PORT:-2345}"
+for i in $(seq 0 $((MINER_COUNT - 1))); do
+    miner="lotus-miner${i}"
+    MINER_URL="http://${miner}:${MINER_RPC_PORT}/rpc/v0"
+    log_info "Waiting for ${miner} API..."
+    while true; do
+        ver=$(curl -sf -m 5 -X POST -H "Content-Type: application/json" \
+            --data '{"jsonrpc":"2.0","method":"Filecoin.Version","params":[],"id":1}' \
+            "$MINER_URL" 2>/dev/null | jq -r '.result.Version // empty' 2>/dev/null)
+        if [ -n "$ver" ]; then
+            log_info "${miner} ready (version=${ver})"
+            break
+        fi
+        sleep 3
+    done
+done
+log_info "All ${MINER_COUNT} miners confirmed reachable."
+
+# ── 5. Wait for filwizard if running (FOC profile, auto-detected via DNS) ──
 ENV_FILE="/shared/environment.env"
 FILWIZARD_READY="/shared/filwizard_ready"
 if getent hosts filwizard &>/dev/null; then
@@ -60,11 +93,11 @@ else
     log_info "Non-FOC profile."
 fi
 
-# ── 5. Signal setup complete to Antithesis ──
+# ── 6. Signal setup complete to Antithesis ──
 log_info "All prerequisites met, signaling setup complete to Antithesis..."
 /opt/antithesis/setup-complete
 
-# ── 6. Launch FOC sidecar if in FOC profile ──
+# ── 7. Launch FOC sidecar if in FOC profile ──
 if getent hosts filwizard &>/dev/null; then
     log_info "Starting FOC sidecar..."
     /opt/antithesis/foc-sidecar &
@@ -72,7 +105,7 @@ if getent hosts filwizard &>/dev/null; then
     log_info "FOC sidecar started (PID=$SIDECAR_PID)"
 fi
 
-# ── 7. Launch stress engine ──
+# ── 8. Launch stress engine ──
 log_info "Launching stress engine..."
 /opt/antithesis/stress-engine &
 STRESS_PID=$!


### PR DESCRIPTION
# Fix premature fault injection by gating setup_complete on miner readiness

## Problem

Antithesis fault injection was killing miners during their initial boot sequence. Analysis of event logs from two Antithesis reports (runs 93/94) showed that `lotus-miner2` and `lotus-miner3` were dying with RPC dial/read timeouts before they had finished connecting to their backing lotus daemons.

**Root cause:** The workload container signaled `setup_complete` (which tells Antithesis to start injecting faults) as soon as the chain reached height 10. With 6-second block times, reaching height 10 takes ~60 seconds, but miners take longer to fully initialize (miner init, sector import, WinningPoSt warmup). Antithesis would inject network partitions while miners were still establishing their initial websocket connections, causing immediate connection-refused or timeout deaths.

**Timeline from logs:**
```
t=0-85s   Chain crawls to height 10
t=85s     setup_complete fired, Antithesis starts fault injection
t=85s     Stress engine + protocol fuzzer launch
t=100s+   lotus-miner1 starts first PoSt cycle
t=137s    lotus-miner2/3 die — never even connected
```

## Two bugs found and fixed

### Bug 1: Miner RPC not accessible from other containers

`start-lotus-miner.sh` was not mapping the per-node env var (`LOTUS_MINER_0_API_LISTENADDRESS`) to the env var that the lotus-miner binary actually reads (`LOTUS_API_LISTENADDRESS`). This caused all miners to bind to `127.0.0.1:2345` instead of `0.0.0.0:2345`, making their RPC unreachable from other containers.

The `.env` file defines:
```
LOTUS_MINER_0_API_LISTENADDRESS=/dns/lotus-miner0/tcp/2345/http
```

But the miner binary reads `LOTUS_API_LISTENADDRESS` (per the config comment `env var: LOTUS_API_LISTENADDRESS`). The startup script already does this indirection pattern for `LOTUS_PATH` and `LOTUS_MINER_PATH` — the API listen address was simply missing.

**Fix in `lotus/scripts/start-lotus-miner.sh`:**
```bash
lotus_miner_api="LOTUS_MINER_${node_number}_API_LISTENADDRESS"
export LOTUS_API_LISTENADDRESS="${!lotus_miner_api}"
```

### Bug 2: setup_complete not gated on miner readiness

The workload entrypoint only waited for chain height before signaling to Antithesis. Now it also:

1. Calls `Filecoin.StateListMiners` on the full node to dynamically discover all registered miners (no hardcoded count)
2. Polls each miner daemon's `Filecoin.Version` RPC endpoint until it responds
3. Only then signals `setup_complete`

**Fix in `workload/entrypoint/entrypoint.sh`** — new section 4 between chain height wait and filwizard check:
```bash
# Discover miners via full node
StateListMiners → found 4 miners: t01000, t01001, t01002, t01003

# Wait for each miner daemon RPC
lotus-miner0 ready (version=1.34.4-dev)
lotus-miner1 ready (version=1.34.4-dev)
lotus-miner2 ready (version=1.34.4-dev)
lotus-miner3 ready (version=1.34.4-dev)

# Now safe to signal setup_complete
```

## Verified output

```
[WORKLOAD] Blockchain ready at height 10
[WORKLOAD] Found 4 miners on-chain: t01002, t01000, t01003, t01001
[WORKLOAD] lotus-miner0 ready (version=1.34.4-dev+2k+git.c72dad9.dirty)
[WORKLOAD] lotus-miner1 ready (version=1.34.4-dev+2k+git.c72dad9.dirty)
[WORKLOAD] lotus-miner2 ready (version=1.34.4-dev+2k+git.c72dad9.dirty)
[WORKLOAD] lotus-miner3 ready (version=1.34.4-dev+2k+git.c72dad9.dirty)
[WORKLOAD] All 4 miners confirmed reachable.
[WORKLOAD] All prerequisites met, signaling setup complete to Antithesis...
[WORKLOAD] Launching stress engine...
```

## Files changed

- `lotus/scripts/start-lotus-miner.sh` — Export `LOTUS_API_LISTENADDRESS` so miner binds to the configured address instead of localhost
- `workload/entrypoint/entrypoint.sh` — Add miner readiness gate before `setup_complete`
