### PR TITLE
fix nsplit consensus test + refactor profile weights for clean reports

### DIFF
--- a/env.consensus
+++ b/env.consensus
@@ -137,45 +137,44 @@ YUGABYTE_PORT_5=9042
 YB_DATA_DIR=/mnt/master
 
 # ======================== WORKLOAD PROFILE ========================
-FUZZER_ENABLED=0 # protocol fuzzer: 0=off, 1=on (uses Go-code defaults for weights)
-# Consensus health-check vectors (HEAVY — partition safety is the focus)
+# FOCUS: EC/F3 safety proofs under adversarial partitions (Wang 2023)
+# Miners produce blocks. nsplit lifecycle injects its own attack txs.
+# No traffic generators needed — assertions only.
+FUZZER_ENABLED=0
+# --- ASSERTIONS (the report) ---
 STRESS_WEIGHT_TIPSET_CONSENSUS=5   # cross-node tipset agreement at finalized height
-STRESS_WEIGHT_HEIGHT_PROGRESSION=4 # assert chain height advances (liveness)
-STRESS_WEIGHT_PEER_COUNT=3         # node peer connectivity check
+STRESS_WEIGHT_HEIGHT_PROGRESSION=4 # chain advances (liveness)
+STRESS_WEIGHT_PEER_COUNT=3         # node connectivity
 STRESS_WEIGHT_HEAD_COMPARISON=5    # cross-node chain head match
 STRESS_WEIGHT_STATE_ROOT=6         # cross-node state root agreement
 STRESS_WEIGHT_STATE_AUDIT=7        # full state tree walk + cross-node comparison
-STRESS_WEIGHT_F3_MONITOR=4         # passive F3 health: instance progression, participation
+STRESS_WEIGHT_F3_MONITOR=4         # F3 instance progression, participation
 STRESS_WEIGHT_F3_AGREEMENT=7       # cross-node F3 certificate consistency
-STRESS_WEIGHT_DRAND_BEACON_AUDIT=3 # cross-node drand beacon entry consistency
-# N-split lifecycle (ACTIVE — structured partition testing is the core focus)
-STRESS_CONSENSUS_TEST=1            # n-split lifecycle: structured EC/F3 partition test cycles
-STRESS_WEIGHT_POWER_SLASH=0        # off — preserve 40/30/20/10 power for clean hypothesis testing
-STRESS_WEIGHT_REORG=0              # off — shallow forks don't test EC finality; avoids n-split interference
-# EVM contract stress (light — just enough state churn for partition reconciliation)
-STRESS_WEIGHT_DEPLOY=1             # deploy contracts via EAM.CreateExternal (state tree growth)
-STRESS_WEIGHT_CONTRACT_CALL=0      # deep recursion, delegatecall, external recursive calls
-STRESS_WEIGHT_SELFDESTRUCT=0       # actor destruction + state consistency across nodes
-STRESS_WEIGHT_CONTRACT_RACE=1      # conflicting txs to different nodes (state divergence)
-STRESS_WEIGHT_MAX_BLOCK_GAS=0      # fill block to gas limit
-STRESS_WEIGHT_LOG_BLASTER=0        # blast event logs (receipt storage, bloom filters)
-STRESS_WEIGHT_MEMORY_BOMB=0        # FVM memory accounting stress
-STRESS_WEIGHT_STORAGE_SPAM=0       # HAMT state trie growth via SSTORE
-# Chain activity (moderate — background churn during partitions)
-STRESS_WEIGHT_TRANSFER=2           # FIL transfers (background state changes)
-STRESS_WEIGHT_GAS_WAR=1            # mempool gas-premium replacement races
-STRESS_WEIGHT_NONCE_RACE=1         # same-nonce different-gas races across nodes
-STRESS_WEIGHT_HEAVY_COMPUTE=1      # expensive state recomputation verification
-# Cross-node consistency
-STRESS_WEIGHT_RECEIPT_AUDIT=4      # assert receipt fields match across every node
-STRESS_WEIGHT_MSG_ORDERING=1       # cross-node message replacement/ordering attacks
-STRESS_WEIGHT_NONCE_BOMBARD=0      # N+x nonce gap handling & out-of-order execution
-STRESS_WEIGHT_GAS_EXHAUST=0        # high-gas call competing with small messages
-# Adversarial (double-spend during partitions is the core test)
-STRESS_WEIGHT_ADVERSARIAL=0        # double-spend attempts, invalid signatures (disabled — redesigning)
-# State tree stress (off — not the focus)
-STRESS_WEIGHT_ACTOR_MIGRATION=0    # burst-create/delete actors, stress HAMT during forks
-STRESS_WEIGHT_ACTOR_LIFECYCLE=0    # full actor create-fund-use-destroy lifecycle
+STRESS_WEIGHT_DRAND_BEACON_AUDIT=3 # cross-node drand beacon consistency
+STRESS_WEIGHT_HEAVY_COMPUTE=1      # state recomputation verification
+# --- N-SPLIT LIFECYCLE (background goroutine, not deck) ---
+STRESS_CONSENSUS_TEST=1            # structured EC/F3 partition test cycles
+# --- EVERYTHING ELSE OFF (no traffic, no noise) ---
+STRESS_WEIGHT_POWER_SLASH=0
+STRESS_WEIGHT_REORG=0
+STRESS_WEIGHT_DEPLOY=0
+STRESS_WEIGHT_CONTRACT_CALL=0
+STRESS_WEIGHT_SELFDESTRUCT=0
+STRESS_WEIGHT_CONTRACT_RACE=0
+STRESS_WEIGHT_MAX_BLOCK_GAS=0
+STRESS_WEIGHT_LOG_BLASTER=0
+STRESS_WEIGHT_MEMORY_BOMB=0
+STRESS_WEIGHT_STORAGE_SPAM=0
+STRESS_WEIGHT_TRANSFER=0
+STRESS_WEIGHT_GAS_WAR=0
+STRESS_WEIGHT_NONCE_RACE=0
+STRESS_WEIGHT_RECEIPT_AUDIT=0
+STRESS_WEIGHT_MSG_ORDERING=0
+STRESS_WEIGHT_NONCE_BOMBARD=0
+STRESS_WEIGHT_GAS_EXHAUST=0
+STRESS_WEIGHT_ADVERSARIAL=0
+STRESS_WEIGHT_ACTOR_MIGRATION=0
+STRESS_WEIGHT_ACTOR_LIFECYCLE=0
 # FOC (off)
 STRESS_WEIGHT_FOC_LIFECYCLE=0      # sequential state machine: Init -> Ready
 STRESS_WEIGHT_FOC_UPLOAD=0         # upload random data to Curio PDP API

--- a/env.drand
+++ b/env.drand
@@ -138,45 +138,43 @@ YUGABYTE_PORT_5=9042
 YB_DATA_DIR=/mnt/master
 
 # ======================== WORKLOAD PROFILE ========================
-FUZZER_ENABLED=0 # protocol fuzzer: 0=off, 1=on (uses Go-code defaults for weights)
-# Consensus health-check vectors (HEAVY — beacon failures manifest here)
-STRESS_WEIGHT_TIPSET_CONSENSUS=5   # cross-node tipset agreement at finalized height
-STRESS_WEIGHT_HEIGHT_PROGRESSION=5 # assert chain height advances (primary liveness signal)
-STRESS_WEIGHT_PEER_COUNT=3         # node peer connectivity check
+# FOCUS: Drand resilience — beacon continuity under drand node faults.
+# Drand containers ARE faultable in this profile (unlike all others).
+# Miners produce blocks. No synthetic traffic needed.
+FUZZER_ENABLED=0
+# --- ASSERTIONS (the report) ---
+STRESS_WEIGHT_DRAND_BEACON_AUDIT=7 # PRIMARY: cross-node drand beacon consistency
+STRESS_WEIGHT_TIPSET_CONSENSUS=5   # tipset agreement (beacon faults cause divergence)
+STRESS_WEIGHT_HEIGHT_PROGRESSION=5 # chain liveness (does chain stall when drand dies?)
+STRESS_WEIGHT_PEER_COUNT=3         # node connectivity
 STRESS_WEIGHT_HEAD_COMPARISON=5    # cross-node chain head match
 STRESS_WEIGHT_STATE_ROOT=4         # cross-node state root agreement
-STRESS_WEIGHT_STATE_AUDIT=3        # full state tree walk + cross-node comparison
-STRESS_WEIGHT_F3_MONITOR=4         # passive F3 health: instance progression, participation
-STRESS_WEIGHT_F3_AGREEMENT=5       # cross-node F3 certificate consistency
-STRESS_WEIGHT_DRAND_BEACON_AUDIT=5 # cross-node drand beacon entry consistency (PRIMARY vector)
-# Power / reorg / n-split (n-split OFF — but shallow reorg adds realism)
-STRESS_CONSENSUS_TEST=0            # n-split lifecycle: structured EC/F3 partition test cycles
-STRESS_WEIGHT_POWER_SLASH=1        # power-aware miner fault reporting
-STRESS_WEIGHT_REORG=1              # rapid shallow partition-heal cycles (reorg chaos)
-# EVM contract stress (low background — realistic conditions during beacon faults)
-STRESS_WEIGHT_DEPLOY=1             # deploy contracts via EAM.CreateExternal (state tree growth)
-STRESS_WEIGHT_CONTRACT_CALL=1      # deep recursion, delegatecall, external recursive calls
-STRESS_WEIGHT_SELFDESTRUCT=0       # actor destruction + state consistency across nodes
-STRESS_WEIGHT_CONTRACT_RACE=1      # conflicting txs to different nodes (state divergence)
-STRESS_WEIGHT_MAX_BLOCK_GAS=0      # fill block to gas limit
-STRESS_WEIGHT_LOG_BLASTER=0        # blast event logs (receipt storage, bloom filters)
-STRESS_WEIGHT_MEMORY_BOMB=0        # FVM memory accounting stress
-STRESS_WEIGHT_STORAGE_SPAM=0       # HAMT state trie growth via SSTORE
-# Chain activity (low background — creates realistic mempool during beacon faults)
-STRESS_WEIGHT_TRANSFER=1           # FIL transfers (background state changes)
-STRESS_WEIGHT_GAS_WAR=1            # mempool gas-premium replacement races
-STRESS_WEIGHT_NONCE_RACE=1         # same-nonce different-gas races across nodes
-STRESS_WEIGHT_HEAVY_COMPUTE=0      # expensive state recomputation verification
-# Cross-node consistency (receipt audit on — beacon faults can cause divergence)
-STRESS_WEIGHT_RECEIPT_AUDIT=3      # assert receipt fields match across every node
-STRESS_WEIGHT_MSG_ORDERING=1       # cross-node message replacement/ordering attacks
-STRESS_WEIGHT_NONCE_BOMBARD=0      # N+x nonce gap handling & out-of-order execution
-STRESS_WEIGHT_GAS_EXHAUST=0        # high-gas call competing with small messages
-# Adversarial (low background)
-STRESS_WEIGHT_ADVERSARIAL=0        # double-spend attempts, invalid signatures (disabled — redesigning)
-# State tree stress (low background)
-STRESS_WEIGHT_ACTOR_MIGRATION=1    # burst-create/delete actors, stress HAMT during forks
-STRESS_WEIGHT_ACTOR_LIFECYCLE=1    # full actor create-fund-use-destroy lifecycle
+STRESS_WEIGHT_F3_MONITOR=4         # does F3 stall when drand dies?
+STRESS_WEIGHT_F3_AGREEMENT=5       # F3 certificate consistency under beacon faults
+STRESS_WEIGHT_STATE_AUDIT=3        # full state tree walk
+# --- EVERYTHING ELSE OFF (no traffic, no noise) ---
+STRESS_CONSENSUS_TEST=0
+STRESS_WEIGHT_POWER_SLASH=0
+STRESS_WEIGHT_REORG=0
+STRESS_WEIGHT_DEPLOY=0
+STRESS_WEIGHT_CONTRACT_CALL=0
+STRESS_WEIGHT_SELFDESTRUCT=0
+STRESS_WEIGHT_CONTRACT_RACE=0
+STRESS_WEIGHT_MAX_BLOCK_GAS=0
+STRESS_WEIGHT_LOG_BLASTER=0
+STRESS_WEIGHT_MEMORY_BOMB=0
+STRESS_WEIGHT_STORAGE_SPAM=0
+STRESS_WEIGHT_TRANSFER=0
+STRESS_WEIGHT_GAS_WAR=0
+STRESS_WEIGHT_NONCE_RACE=0
+STRESS_WEIGHT_HEAVY_COMPUTE=0
+STRESS_WEIGHT_RECEIPT_AUDIT=0
+STRESS_WEIGHT_MSG_ORDERING=0
+STRESS_WEIGHT_NONCE_BOMBARD=0
+STRESS_WEIGHT_GAS_EXHAUST=0
+STRESS_WEIGHT_ADVERSARIAL=0
+STRESS_WEIGHT_ACTOR_MIGRATION=0
+STRESS_WEIGHT_ACTOR_LIFECYCLE=0
 # FOC (OFF)
 STRESS_WEIGHT_FOC_LIFECYCLE=0      # sequential state machine: Init -> Ready
 STRESS_WEIGHT_FOC_UPLOAD=0         # upload random data to Curio PDP API

--- a/env.fip
+++ b/env.fip
@@ -138,45 +138,44 @@ YUGABYTE_PORT_5=9042
 YB_DATA_DIR=/mnt/master
 
 # ======================== WORKLOAD PROFILE ========================
-FUZZER_ENABLED=0 # protocol fuzzer: 0=off, 1=on (uses Go-code defaults for weights)
-# Consensus health-check vectors (moderate — state audit HEAVY for migration correctness)
-STRESS_WEIGHT_TIPSET_CONSENSUS=3   # cross-node tipset agreement at finalized height
-STRESS_WEIGHT_HEIGHT_PROGRESSION=3 # assert chain height advances (liveness)
-STRESS_WEIGHT_PEER_COUNT=1         # node peer connectivity check
-STRESS_WEIGHT_HEAD_COMPARISON=3    # cross-node chain head match
-STRESS_WEIGHT_STATE_ROOT=5         # cross-node state root agreement
-STRESS_WEIGHT_STATE_AUDIT=6        # full state tree walk + cross-node comparison
-STRESS_WEIGHT_F3_MONITOR=2         # passive F3 health: instance progression, participation
-STRESS_WEIGHT_F3_AGREEMENT=3       # cross-node F3 certificate consistency
-STRESS_WEIGHT_DRAND_BEACON_AUDIT=3 # cross-node drand beacon entry consistency
-# Power / reorg / n-split
-STRESS_CONSENSUS_TEST=0            # n-split lifecycle: structured EC/F3 partition test cycles
-STRESS_WEIGHT_POWER_SLASH=1        # power-aware miner fault reporting
-STRESS_WEIGHT_REORG=1              # rapid shallow partition-heal cycles (test upgrade during fork)
-# EVM contract stress (active — gas schedule changes across upgrades)
-STRESS_WEIGHT_DEPLOY=2             # deploy contracts via EAM.CreateExternal (state tree growth)
-STRESS_WEIGHT_CONTRACT_CALL=2      # deep recursion, delegatecall, external recursive calls
-STRESS_WEIGHT_SELFDESTRUCT=1       # actor destruction + state consistency across nodes
-STRESS_WEIGHT_CONTRACT_RACE=2      # conflicting txs to different nodes (state divergence)
-STRESS_WEIGHT_MAX_BLOCK_GAS=1      # fill block to gas limit (gas limit edge cases across FIPs)
-STRESS_WEIGHT_LOG_BLASTER=1        # blast event logs (receipt storage, bloom filters)
-STRESS_WEIGHT_MEMORY_BOMB=1        # FVM memory accounting stress
-STRESS_WEIGHT_STORAGE_SPAM=1       # HAMT state trie growth via SSTORE
-# Chain activity (moderate — state churn around upgrade window)
-STRESS_WEIGHT_TRANSFER=2           # FIL transfers (background state changes)
-STRESS_WEIGHT_GAS_WAR=1            # mempool gas-premium replacement races
-STRESS_WEIGHT_NONCE_RACE=1         # same-nonce different-gas races across nodes
-STRESS_WEIGHT_HEAVY_COMPUTE=1      # expensive state recomputation verification
-# Cross-node consistency (HEAVY — upgrade mismatches show up here)
-STRESS_WEIGHT_RECEIPT_AUDIT=6      # assert receipt fields match across every node
-STRESS_WEIGHT_MSG_ORDERING=2       # cross-node message replacement/ordering attacks
-STRESS_WEIGHT_NONCE_BOMBARD=1      # N+x nonce gap handling & out-of-order execution
-STRESS_WEIGHT_GAS_EXHAUST=1        # high-gas call competing with small messages
-# Adversarial
-STRESS_WEIGHT_ADVERSARIAL=0        # double-spend attempts, invalid signatures (disabled — redesigning)
-# State tree stress (HEAVY — actor migration is the core upgrade stress)
-STRESS_WEIGHT_ACTOR_MIGRATION=4    # burst-create/delete actors, stress HAMT during forks
-STRESS_WEIGHT_ACTOR_LIFECYCLE=3    # full actor create-fund-use-destroy lifecycle
+# FOCUS: Network upgrade correctness (GOLDENWEEK=50, XX=200).
+# NEEDS traffic — FIP-0115 changes gas fees, needs full mempool at upgrade.
+# Traffic generators ON but assertions come from cross-node consistency checks.
+FUZZER_ENABLED=0
+# --- ASSERTIONS (the report) ---
+STRESS_WEIGHT_STATE_ROOT=6         # PRIMARY: cross-node state root agreement
+STRESS_WEIGHT_STATE_AUDIT=7        # PRIMARY: full state tree walk + cross-node comparison
+STRESS_WEIGHT_RECEIPT_AUDIT=6      # PRIMARY: receipt match (gas fee changes show here)
+STRESS_WEIGHT_TIPSET_CONSENSUS=3   # tipset agreement
+STRESS_WEIGHT_HEIGHT_PROGRESSION=3 # chain liveness
+STRESS_WEIGHT_HEAD_COMPARISON=3    # cross-node head match
+STRESS_WEIGHT_F3_MONITOR=2         # F3 continuity across upgrade
+STRESS_WEIGHT_F3_AGREEMENT=3       # F3 certificate consistency
+STRESS_WEIGHT_DRAND_BEACON_AUDIT=2 # beacon consistency
+STRESS_WEIGHT_HEAVY_COMPUTE=2      # state recomputation (catches non-deterministic migrations)
+# --- TRAFFIC (feeds the mempool for FIP-0115 base fee testing) ---
+STRESS_WEIGHT_TRANSFER=2           # FIL transfers
+STRESS_WEIGHT_GAS_WAR=2            # gas premium races (exercises FIP-0115 premium percentile)
+STRESS_WEIGHT_DEPLOY=2             # EVM deploys (gas schedule changes)
+STRESS_WEIGHT_CONTRACT_CALL=1      # contract calls (gas accounting)
+STRESS_WEIGHT_MAX_BLOCK_GAS=1      # fill block to gas limit
+STRESS_WEIGHT_ACTOR_MIGRATION=3    # HAMT stress during state migration
+STRESS_WEIGHT_ACTOR_LIFECYCLE=2    # actor create/destroy across upgrade
+# --- OFF (not relevant to upgrade testing) ---
+STRESS_CONSENSUS_TEST=0
+STRESS_WEIGHT_PEER_COUNT=0
+STRESS_WEIGHT_POWER_SLASH=0
+STRESS_WEIGHT_REORG=0
+STRESS_WEIGHT_SELFDESTRUCT=0
+STRESS_WEIGHT_CONTRACT_RACE=0
+STRESS_WEIGHT_LOG_BLASTER=0
+STRESS_WEIGHT_MEMORY_BOMB=0
+STRESS_WEIGHT_STORAGE_SPAM=0
+STRESS_WEIGHT_NONCE_RACE=0
+STRESS_WEIGHT_MSG_ORDERING=0
+STRESS_WEIGHT_NONCE_BOMBARD=0
+STRESS_WEIGHT_GAS_EXHAUST=0
+STRESS_WEIGHT_ADVERSARIAL=0
 # FOC (OFF)
 STRESS_WEIGHT_FOC_LIFECYCLE=0      # sequential state machine: Init -> Ready
 STRESS_WEIGHT_FOC_UPLOAD=0         # upload random data to Curio PDP API

--- a/env.foc
+++ b/env.foc
@@ -137,45 +137,44 @@ YUGABYTE_PORT_5=9042
 YB_DATA_DIR=/mnt/master
 
 # ======================== WORKLOAD PROFILE ========================
-FUZZER_ENABLED=0 # protocol fuzzer: 0=off, 1=on (uses Go-code defaults for weights)
-# Consensus health-check vectors (moderate — chain health needed but not the focus)
-STRESS_WEIGHT_TIPSET_CONSENSUS=3   # cross-node tipset agreement at finalized height
-STRESS_WEIGHT_HEIGHT_PROGRESSION=2 # assert chain height advances (liveness)
-STRESS_WEIGHT_PEER_COUNT=1         # node peer connectivity check
-STRESS_WEIGHT_HEAD_COMPARISON=3    # cross-node chain head match
-STRESS_WEIGHT_STATE_ROOT=3         # cross-node state root agreement
-STRESS_WEIGHT_STATE_AUDIT=3        # full state tree walk + cross-node comparison
-STRESS_WEIGHT_F3_MONITOR=2         # passive F3 health: instance progression, participation
-STRESS_WEIGHT_F3_AGREEMENT=3       # cross-node F3 certificate consistency
-STRESS_WEIGHT_DRAND_BEACON_AUDIT=3 # cross-node drand beacon entry consistency
-# Power / reorg / n-split (reorg ON for Curio chain-tracking stress)
-STRESS_CONSENSUS_TEST=0            # n-split lifecycle: structured EC/F3 partition test cycles
-STRESS_WEIGHT_POWER_SLASH=0        # power-aware miner fault reporting
-STRESS_WEIGHT_REORG=1              # rapid shallow partition-heal cycles (reorg chaos)
-# EVM contract stress (low background — Curio operates on a noisy chain)
-STRESS_WEIGHT_DEPLOY=1             # deploy contracts via EAM.CreateExternal (state tree growth)
-STRESS_WEIGHT_CONTRACT_CALL=1      # deep recursion, delegatecall, external recursive calls
-STRESS_WEIGHT_SELFDESTRUCT=0       # actor destruction + state consistency across nodes
-STRESS_WEIGHT_CONTRACT_RACE=1      # conflicting txs to different nodes (state divergence)
-STRESS_WEIGHT_MAX_BLOCK_GAS=0      # fill block to gas limit
-STRESS_WEIGHT_LOG_BLASTER=0        # blast event logs (receipt storage, bloom filters)
-STRESS_WEIGHT_MEMORY_BOMB=0        # FVM memory accounting stress
-STRESS_WEIGHT_STORAGE_SPAM=0       # HAMT state trie growth via SSTORE
-# Chain activity (low background)
-STRESS_WEIGHT_TRANSFER=1           # FIL transfers (background state changes)
-STRESS_WEIGHT_GAS_WAR=1            # mempool gas-premium replacement races
-STRESS_WEIGHT_NONCE_RACE=1         # same-nonce different-gas races across nodes
-STRESS_WEIGHT_HEAVY_COMPUTE=0      # expensive state recomputation verification
-# Cross-node consistency
-STRESS_WEIGHT_RECEIPT_AUDIT=2      # assert receipt fields match across every node
-STRESS_WEIGHT_MSG_ORDERING=1       # cross-node message replacement/ordering attacks
-STRESS_WEIGHT_NONCE_BOMBARD=0      # N+x nonce gap handling & out-of-order execution
-STRESS_WEIGHT_GAS_EXHAUST=0        # high-gas call competing with small messages
-# Adversarial (low background)
-STRESS_WEIGHT_ADVERSARIAL=0        # double-spend attempts, invalid signatures (disabled — redesigning)
-# State tree stress (low background)
-STRESS_WEIGHT_ACTOR_MIGRATION=1    # burst-create/delete actors, stress HAMT during forks
-STRESS_WEIGHT_ACTOR_LIFECYCLE=1    # full actor create-fund-use-destroy lifecycle
+# FOCUS: Curio PDP correctness — proofset lifecycle, retrieval, payments.
+# Needs reorg chaos for Curio chain-tracking stress.
+# Minimal consensus assertions — just enough to know the chain is healthy.
+FUZZER_ENABLED=0
+# --- ASSERTIONS (chain health baseline) ---
+STRESS_WEIGHT_TIPSET_CONSENSUS=2   # basic chain health
+STRESS_WEIGHT_HEIGHT_PROGRESSION=2 # chain liveness
+STRESS_WEIGHT_STATE_ROOT=2         # state agreement
+STRESS_WEIGHT_RECEIPT_AUDIT=2      # receipt match (Curio txs)
+STRESS_WEIGHT_F3_MONITOR=1         # F3 health
+STRESS_WEIGHT_REORG=1              # shallow reorgs (Curio chain-tracking stress)
+# --- TRAFFIC (Curio needs a live chain) ---
+STRESS_WEIGHT_TRANSFER=1           # FIL transfers
+# --- OFF (not relevant to PDP testing) ---
+STRESS_WEIGHT_PEER_COUNT=0
+STRESS_WEIGHT_HEAD_COMPARISON=0
+STRESS_WEIGHT_STATE_AUDIT=0
+STRESS_WEIGHT_F3_AGREEMENT=0
+STRESS_WEIGHT_DRAND_BEACON_AUDIT=0
+STRESS_CONSENSUS_TEST=0
+STRESS_WEIGHT_POWER_SLASH=0
+STRESS_WEIGHT_DEPLOY=0
+STRESS_WEIGHT_CONTRACT_CALL=0
+STRESS_WEIGHT_SELFDESTRUCT=0
+STRESS_WEIGHT_CONTRACT_RACE=0
+STRESS_WEIGHT_MAX_BLOCK_GAS=0
+STRESS_WEIGHT_LOG_BLASTER=0
+STRESS_WEIGHT_MEMORY_BOMB=0
+STRESS_WEIGHT_STORAGE_SPAM=0
+STRESS_WEIGHT_GAS_WAR=0
+STRESS_WEIGHT_NONCE_RACE=0
+STRESS_WEIGHT_HEAVY_COMPUTE=0
+STRESS_WEIGHT_MSG_ORDERING=0
+STRESS_WEIGHT_NONCE_BOMBARD=0
+STRESS_WEIGHT_GAS_EXHAUST=0
+STRESS_WEIGHT_ADVERSARIAL=0
+STRESS_WEIGHT_ACTOR_MIGRATION=0
+STRESS_WEIGHT_ACTOR_LIFECYCLE=0
 # FOC (HEAVY — this is the focus)
 STRESS_WEIGHT_FOC_LIFECYCLE=6      # sequential state machine: Init -> Ready
 STRESS_WEIGHT_FOC_UPLOAD=4         # upload random data to Curio PDP API

--- a/env.nightly
+++ b/env.nightly
@@ -137,45 +137,44 @@ YUGABYTE_PORT_5=9042
 YB_DATA_DIR=/mnt/master
 
 # ======================== WORKLOAD PROFILE ========================
-FUZZER_ENABLED=0 # protocol fuzzer: 0=off, 1=on (uses Go-code defaults for weights)
-# Consensus health-check vectors
-STRESS_WEIGHT_TIPSET_CONSENSUS=3   # cross-node tipset agreement at finalized height
-STRESS_WEIGHT_HEIGHT_PROGRESSION=2 # assert chain height advances (liveness)
-STRESS_WEIGHT_PEER_COUNT=1         # node peer connectivity check
-STRESS_WEIGHT_HEAD_COMPARISON=3    # cross-node chain head match
+# FOCUS: Broad regression canary — exercises everything at moderate weight.
+# This IS the kitchen sink, intentionally. Catches regressions across the
+# entire SUT surface. Traffic generators ON for realistic load.
+FUZZER_ENABLED=0
+# --- ASSERTIONS (broad coverage) ---
+STRESS_WEIGHT_TIPSET_CONSENSUS=3   # cross-node tipset agreement
+STRESS_WEIGHT_HEIGHT_PROGRESSION=2 # chain liveness
+STRESS_WEIGHT_PEER_COUNT=1         # node connectivity
+STRESS_WEIGHT_HEAD_COMPARISON=3    # cross-node head match
 STRESS_WEIGHT_STATE_ROOT=4         # cross-node state root agreement
-STRESS_WEIGHT_STATE_AUDIT=3        # full state tree walk + cross-node comparison
-STRESS_WEIGHT_F3_MONITOR=2         # passive F3 health: instance progression, participation
-STRESS_WEIGHT_F3_AGREEMENT=3       # cross-node F3 certificate consistency
-STRESS_WEIGHT_DRAND_BEACON_AUDIT=3 # cross-node drand beacon entry consistency
-# Power / reorg / n-split
-STRESS_CONSENSUS_TEST=0            # n-split lifecycle: structured EC/F3 partition test cycles
-STRESS_WEIGHT_POWER_SLASH=2        # power-aware miner fault reporting
-STRESS_WEIGHT_REORG=1              # rapid shallow partition-heal cycles (reorg chaos)
-# EVM contract stress
-STRESS_WEIGHT_DEPLOY=1             # deploy contracts via EAM.CreateExternal (state tree growth)
-STRESS_WEIGHT_CONTRACT_CALL=1      # deep recursion, delegatecall, external recursive calls
-STRESS_WEIGHT_SELFDESTRUCT=1       # actor destruction + state consistency across nodes
-STRESS_WEIGHT_CONTRACT_RACE=2      # conflicting txs to different nodes (state divergence)
-STRESS_WEIGHT_MAX_BLOCK_GAS=1      # fill block to gas limit
-STRESS_WEIGHT_LOG_BLASTER=1        # blast event logs (receipt storage, bloom filters)
-STRESS_WEIGHT_MEMORY_BOMB=1        # FVM memory accounting stress
-STRESS_WEIGHT_STORAGE_SPAM=1       # HAMT state trie growth via SSTORE
-# Chain activity
-STRESS_WEIGHT_TRANSFER=2           # FIL transfers (background state changes)
-STRESS_WEIGHT_GAS_WAR=1            # mempool gas-premium replacement races
-STRESS_WEIGHT_NONCE_RACE=1         # same-nonce different-gas races across nodes
-STRESS_WEIGHT_HEAVY_COMPUTE=1      # expensive state recomputation verification
-# Cross-node consistency
-STRESS_WEIGHT_RECEIPT_AUDIT=3      # assert receipt fields match across every node
-STRESS_WEIGHT_MSG_ORDERING=1       # cross-node message replacement/ordering attacks
-STRESS_WEIGHT_NONCE_BOMBARD=1      # N+x nonce gap handling & out-of-order execution
-STRESS_WEIGHT_GAS_EXHAUST=1        # high-gas call competing with small messages
-# Adversarial
-STRESS_WEIGHT_ADVERSARIAL=0        # double-spend attempts, invalid signatures (disabled — redesigning)
-# State tree stress
-STRESS_WEIGHT_ACTOR_MIGRATION=1    # burst-create/delete actors, stress HAMT during forks
-STRESS_WEIGHT_ACTOR_LIFECYCLE=1    # full actor create-fund-use-destroy lifecycle
+STRESS_WEIGHT_STATE_AUDIT=3        # full state tree walk
+STRESS_WEIGHT_F3_MONITOR=2         # F3 health
+STRESS_WEIGHT_F3_AGREEMENT=3       # F3 certificate consistency
+STRESS_WEIGHT_DRAND_BEACON_AUDIT=3 # drand beacon consistency
+STRESS_WEIGHT_RECEIPT_AUDIT=3      # receipt match across nodes
+STRESS_WEIGHT_HEAVY_COMPUTE=1      # state recomputation
+STRESS_WEIGHT_REORG=1              # shallow reorg chaos
+STRESS_WEIGHT_POWER_SLASH=1        # power-aware fault reporting
+# --- TRAFFIC (realistic network load) ---
+STRESS_WEIGHT_TRANSFER=2           # FIL transfers
+STRESS_WEIGHT_GAS_WAR=1            # gas premium races
+STRESS_WEIGHT_NONCE_RACE=1         # nonce races across nodes
+STRESS_WEIGHT_DEPLOY=1             # EVM deploys
+STRESS_WEIGHT_CONTRACT_CALL=1      # contract execution
+STRESS_WEIGHT_SELFDESTRUCT=1       # actor destruction
+STRESS_WEIGHT_CONTRACT_RACE=1      # conflicting contract calls
+STRESS_WEIGHT_MSG_ORDERING=1       # message ordering attacks
+STRESS_WEIGHT_ACTOR_MIGRATION=1    # HAMT stress
+STRESS_WEIGHT_ACTOR_LIFECYCLE=1    # actor lifecycle
+# --- OFF (specialized, covered by dedicated profiles) ---
+STRESS_CONSENSUS_TEST=0            # covered by consensus profile
+STRESS_WEIGHT_ADVERSARIAL=0        # disabled, redesigning
+STRESS_WEIGHT_MAX_BLOCK_GAS=0
+STRESS_WEIGHT_LOG_BLASTER=0
+STRESS_WEIGHT_MEMORY_BOMB=0
+STRESS_WEIGHT_STORAGE_SPAM=0
+STRESS_WEIGHT_NONCE_BOMBARD=0
+STRESS_WEIGHT_GAS_EXHAUST=0
 # FOC (off in nightly)
 STRESS_WEIGHT_FOC_LIFECYCLE=0      # sequential state machine: Init -> Ready
 STRESS_WEIGHT_FOC_UPLOAD=0         # upload random data to Curio PDP API


### PR DESCRIPTION
## Summary
Two major changes from the Apr 11 nightly triage findings:

**1. nsplit consensus test audit fixes**
- Star split now implements proper Wang 2023 §6 hub-and-spoke topology (adversary as hub, honest miners isolated from each other). Previously was full fragmentation — weaker than the paper's attack model.
- Block forest0 in all partition strategies to prevent gossipsub bridge that silently breaks partitions.
- Re-check F3 active state after partition heal; downgrade assertions if F3 stalled mid-cycle.
- Verify outcomes on honest-side node, not random node that could be the adversary.
- `waitForDivergence` checks tipset CID fork at same height, not just height difference.
- Fix nonce gap on partial push failure.
- Add `assert.Reachable` for chain divergence coverage signal.
- Add `assert.Sometimes` tracking when neither tx lands under EC-vulnerable partition.

**2. Profile weight refactor — assertions-only for focused profiles**
Each profile now separates assertions (report properties) from traffic (load generators) from noise (off):
- **consensus**: assertions-only, zero traffic. Miners produce blocks, nsplit injects its own txs. Report shows ~10 EC/F3 safety properties, not 40+.
- **drand**: assertions-only, zero traffic. Drand beacon audit at weight 7, chain health checks.
- **fip**: assertions + traffic. Needs full mempool for FIP-0115 base fee testing.
- **foc**: minimal chain health + FOC vectors only.
- **nightly**: broad canary, trimmed dead-weight vectors.

**3. Disable adversarial double-spend across all profiles**
The random DoAdversarial produced 0/65 pass rate with no confidence on root cause. Disabled pending redesign as structured test in the nsplit lifecycle.

## Context
The Apr 11 nightly report had 91 passed properties — most irrelevant to what was being tested. Reports are criticized for noise. This refactor ensures each profile's report only shows properties relevant to its hypothesis.

## Test plan
- [x] `go build ./cmd/stress-engine` — compiles clean
- [x] `go vet ./cmd/stress-engine` — no warnings
- [ ] Run consensus profile and verify:
  - Star split logs show hub-and-spoke topology
  - Report has ~10 properties, not 40+
  - `assert.Reachable("Partition achieved chain divergence")` fires
- [ ] Run drand profile and verify report is focused on beacon properties
- [ ] Run nightly and verify broad coverage still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)