### PR TITLE
fix FOC profile: restore chain health weights, protect lotus0 from reorg

### DIFF
--- a/env.foc
+++ b/env.foc
@@ -138,24 +138,27 @@ YB_DATA_DIR=/mnt/master
 
 # ======================== WORKLOAD PROFILE ========================
 # FOCUS: Curio PDP correctness — proofset lifecycle, retrieval, payments.
-# Needs reorg chaos for Curio chain-tracking stress.
-# Minimal consensus assertions — just enough to know the chain is healthy.
+# 3-node setup (lotus0/1/2). lotus0 is Curio's backend — protected from reorg.
+# Reorgs target lotus1/lotus2 only for benign chain-tracking stress.
 FUZZER_ENABLED=0
-# --- ASSERTIONS (chain health baseline) ---
+# --- ASSERTIONS (chain health — needed to distinguish chain vs Curio failures) ---
 STRESS_WEIGHT_TIPSET_CONSENSUS=2   # basic chain health
 STRESS_WEIGHT_HEIGHT_PROGRESSION=2 # chain liveness
+STRESS_WEIGHT_PEER_COUNT=1         # node connectivity (3 nodes = fragile)
+STRESS_WEIGHT_HEAD_COMPARISON=2    # cross-node head match
 STRESS_WEIGHT_STATE_ROOT=2         # state agreement
-STRESS_WEIGHT_RECEIPT_AUDIT=2      # receipt match (Curio txs)
-STRESS_WEIGHT_F3_MONITOR=1         # F3 health
+STRESS_WEIGHT_STATE_AUDIT=1        # periodic state tree walk
+STRESS_WEIGHT_RECEIPT_AUDIT=2      # receipt match (Curio txs visible here)
+STRESS_WEIGHT_F3_MONITOR=1         # F3 health (detects stalls)
+STRESS_WEIGHT_F3_AGREEMENT=1       # F3 certificate consistency
+STRESS_WEIGHT_DRAND_BEACON_AUDIT=1 # beacon consistency
 STRESS_WEIGHT_REORG=1              # shallow reorgs (Curio chain-tracking stress)
+# lotus0 protected from reorg victim selection (Curio's backend).
+# Reorgs target lotus1/lotus2 only. Persistent forks from F3 equivocation
+# are a known go-f3 bug, expected noise until upstream fix ships.
 # --- TRAFFIC (Curio needs a live chain) ---
 STRESS_WEIGHT_TRANSFER=1           # FIL transfers
 # --- OFF (not relevant to PDP testing) ---
-STRESS_WEIGHT_PEER_COUNT=0
-STRESS_WEIGHT_HEAD_COMPARISON=0
-STRESS_WEIGHT_STATE_AUDIT=0
-STRESS_WEIGHT_F3_AGREEMENT=0
-STRESS_WEIGHT_DRAND_BEACON_AUDIT=0
 STRESS_CONSENSUS_TEST=0
 STRESS_WEIGHT_POWER_SLASH=0
 STRESS_WEIGHT_DEPLOY=0

--- a/workload/cmd/stress-engine/reorg_vectors.go
+++ b/workload/cmd/stress-engine/reorg_vectors.go
@@ -49,7 +49,21 @@ func pickReorgVictim() (victimName string, powerPct float64) {
 		table := getF3PowerTable(lotusNode)
 		if len(table) >= 2 {
 			var target minerPowerInfo
-			if rngIntn(2) == 0 {
+			if focCfg != nil {
+				// FOC active: protect lotus0 (Curio's backend).
+				// Only target non-lotus0 miners for benign reorgs.
+				var candidates []minerPowerInfo
+				for _, m := range table {
+					if minerToNodeName(m.addr) != "lotus0" {
+						candidates = append(candidates, m)
+					}
+				}
+				if len(candidates) > 0 {
+					target = candidates[rngIntn(len(candidates))]
+				} else {
+					target = table[len(table)-1]
+				}
+			} else if rngIntn(2) == 0 {
 				target = table[0] // biggest
 			} else {
 				target = table[len(table)-1] // smallest
@@ -77,8 +91,13 @@ func DoReorgChaos() {
 	victimName, victimPowerPct := pickReorgVictim()
 	victim := nodes[victimName]
 
-	// Random number of rapid split-heal cycles: 1-10
-	numCycles := rngIntn(reorgMaxCyclesPerCall) + 1
+	// Random number of rapid split-heal cycles.
+	// FOC: lighter reorgs (1-3) to avoid disrupting Curio lifecycle.
+	maxCycles := reorgMaxCyclesPerCall
+	if focCfg != nil {
+		maxCycles = 3
+	}
+	numCycles := rngIntn(maxCycles) + 1
 
 	if victimPowerPct > 0 {
 		log.Printf("[reorg-chaos] starting %d rapid partition cycles, victim=%s (%.1f%% power)", numCycles, victimName, victimPowerPct)


### PR DESCRIPTION
env.foc:
- Restore chain health assertions at low weight (peer count, head comparison, state audit, F3 agreement, drand beacon) — needed to distinguish chain-level failures from Curio-level failures in triage.
- Document that lotus0 is protected from reorg (Curio's backend).

reorg_vectors.go:
- When FOC is active, exclude lotus0 from reorg victim selection. Curio hardcodes LOTUS_PATH to lotus0 — partitioning it breaks chain tracking and PDP API, causing dataset creation timeouts.
- Reduce max reorg cycles from 10 to 3 when FOC active — lighter reorgs for benign chain-tracking stress without disrupting lifecycle.