### PR TITLE
feat: EC finality fallback when F3 stalls after miner slash

### DIFF
--- a/workload/cmd/stress-engine/consensus_vectors.go
+++ b/workload/cmd/stress-engine/consensus_vectors.go
@@ -117,6 +117,11 @@ const (
 	// snapshotTTL controls how long a finalized-tipset snapshot is reused.
 	// Multiple consensus checks hitting the same deck tick share one fetch round.
 	snapshotTTL = 2 * time.Second
+
+	// EC finality fallback: when F3 stalls (e.g. quorum loss from miner slash),
+	// consensus vectors fall back to EC-based finality so assertions keep working.
+	ecFinalityDepth    = abi.ChainEpoch(30) // depth below head for EC fallback
+	f3StallGraceEpochs = abi.ChainEpoch(50) // head must advance this far past last F3 finalization before fallback activates
 )
 
 // ---------------------------------------------------------------------------
@@ -139,11 +144,46 @@ var (
 	snapCache   map[string]nodeSnapshot // nodeName -> snapshot
 	snapCacheMu sync.Mutex
 	snapCacheAt time.Time
+
+	// F3 stall detection state (protected by snapCacheMu)
+	f3LastFinalizedH    abi.ChainEpoch // highest observed minimum finalized height
+	f3HeadAtLastAdvance abi.ChainEpoch // max chain head when f3LastFinalizedH last changed
+	f3FallbackActive    bool           // true when EC fallback is in use
 )
+
+// f3StallState holds the F3 stall detection state machine inputs/outputs.
+type f3StallState struct {
+	lastFinalizedH    abi.ChainEpoch
+	headAtLastAdvance abi.ChainEpoch
+	fallbackActive    bool
+}
+
+// updateF3StallDetection is a pure function implementing the F3 stall detection
+// state machine. Separated from getFinalizedSnapshots for testability.
+func updateF3StallDetection(prev f3StallState, minFinH, maxHead abi.ChainEpoch, finCount int) f3StallState {
+	s := prev
+	if minFinH > s.lastFinalizedH {
+		s.lastFinalizedH = minFinH
+		s.headAtLastAdvance = maxHead
+		if s.fallbackActive {
+			log.Printf("[finalized] F3 resumed at height %d — deactivating EC fallback", minFinH)
+			s.fallbackActive = false
+		}
+	} else if finCount >= 2 && maxHead-s.headAtLastAdvance >= f3StallGraceEpochs && !s.fallbackActive {
+		log.Printf("[finalized] F3 stall detected: finalized stuck at %d, head at %d (+%d epochs since last F3 advance) — activating EC fallback (head-%d)",
+			s.lastFinalizedH, maxHead, maxHead-s.headAtLastAdvance, ecFinalityDepth)
+		s.fallbackActive = true
+	}
+	return s
+}
 
 // getFinalizedSnapshots returns a cached-or-fresh map of each node's finalized
 // tipset. Safe to call from any deck vector — concurrent callers within the
 // TTL window share the same result.
+//
+// When F3 stalls (finalized height frozen while chain head advances), falls
+// back to EC-based finality (head - ecFinalityDepth) so consensus vectors
+// keep checking new state instead of going blind.
 func getFinalizedSnapshots() map[string]nodeSnapshot {
 	snapCacheMu.Lock()
 	defer snapCacheMu.Unlock()
@@ -165,6 +205,65 @@ func getFinalizedSnapshots() map[string]nodeSnapshot {
 			key:    ts.Key(),
 		}
 	}
+
+	// --- F3 stall detection ---
+	var minFinH abi.ChainEpoch
+	finCount := 0
+	for _, s := range snap {
+		if s.err != nil {
+			continue
+		}
+		finCount++
+		if finCount == 1 || s.height < minFinH {
+			minFinH = s.height
+		}
+	}
+
+	var maxHead abi.ChainEpoch
+	for _, name := range nodeKeys {
+		head, err := nodes[name].ChainHead(ctx)
+		if err != nil {
+			continue
+		}
+		if head.Height() > maxHead {
+			maxHead = head.Height()
+		}
+	}
+
+	state := f3StallState{
+		lastFinalizedH:    f3LastFinalizedH,
+		headAtLastAdvance: f3HeadAtLastAdvance,
+		fallbackActive:    f3FallbackActive,
+	}
+	state = updateF3StallDetection(state, minFinH, maxHead, finCount)
+	f3LastFinalizedH = state.lastFinalizedH
+	f3HeadAtLastAdvance = state.headAtLastAdvance
+	f3FallbackActive = state.fallbackActive
+
+	if f3FallbackActive && maxHead > ecFinalityDepth {
+		for _, name := range nodeKeys {
+			head, err := nodes[name].ChainHead(ctx)
+			if err != nil {
+				snap[name] = nodeSnapshot{err: err}
+				continue
+			}
+			ecHeight := head.Height() - ecFinalityDepth
+			if ecHeight < 1 {
+				ecHeight = 1
+			}
+			ts, err := nodes[name].ChainGetTipSetByHeight(ctx, ecHeight, head.Key())
+			if err != nil {
+				snap[name] = nodeSnapshot{err: err}
+				continue
+			}
+			snap[name] = nodeSnapshot{
+				finTs:  ts,
+				height: ts.Height(),
+				key:    ts.Key(),
+			}
+		}
+	}
+
 	snapCache = snap
 	snapCacheAt = time.Now()
 	return snap

--- a/workload/cmd/stress-engine/consensus_vectors_test.go
+++ b/workload/cmd/stress-engine/consensus_vectors_test.go
@@ -1,0 +1,178 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/filecoin-project/go-state-types/abi"
+)
+
+func TestF3StallDetection(t *testing.T) {
+	tests := []struct {
+		name           string
+		prev           f3StallState
+		minFinH        abi.ChainEpoch
+		maxHead        abi.ChainEpoch
+		finCount       int
+		wantFallback   bool
+		wantLastFinH   abi.ChainEpoch
+		wantHeadAtAdv  abi.ChainEpoch
+	}{
+		{
+			name:         "initial state — F3 advancing",
+			prev:         f3StallState{lastFinalizedH: 0, headAtLastAdvance: 0},
+			minFinH:      100,
+			maxHead:      110,
+			finCount:     2,
+			wantFallback: false,
+			wantLastFinH: 100,
+			wantHeadAtAdv: 110,
+		},
+		{
+			name:         "F3 keeps advancing — no fallback",
+			prev:         f3StallState{lastFinalizedH: 100, headAtLastAdvance: 110},
+			minFinH:      120,
+			maxHead:      130,
+			finCount:     2,
+			wantFallback: false,
+			wantLastFinH: 120,
+			wantHeadAtAdv: 130,
+		},
+		{
+			name:         "F3 stalled but within grace period — no fallback yet",
+			prev:         f3StallState{lastFinalizedH: 100, headAtLastAdvance: 110},
+			minFinH:      100,
+			maxHead:      140,
+			finCount:     2,
+			wantFallback: false,
+			wantLastFinH: 100,
+			wantHeadAtAdv: 110,
+		},
+		{
+			name:         "F3 stalled past grace period — fallback activates",
+			prev:         f3StallState{lastFinalizedH: 100, headAtLastAdvance: 110},
+			minFinH:      100,
+			maxHead:      161,
+			finCount:     2,
+			wantFallback: true,
+			wantLastFinH: 100,
+			wantHeadAtAdv: 110,
+		},
+		{
+			name:         "F3 stalled exactly at grace boundary — fallback activates",
+			prev:         f3StallState{lastFinalizedH: 100, headAtLastAdvance: 110},
+			minFinH:      100,
+			maxHead:      160,
+			finCount:     2,
+			wantFallback: true,
+			wantLastFinH: 100,
+			wantHeadAtAdv: 110,
+		},
+		{
+			name:         "fallback already active — stays active while stalled",
+			prev:         f3StallState{lastFinalizedH: 100, headAtLastAdvance: 110, fallbackActive: true},
+			minFinH:      100,
+			maxHead:      200,
+			finCount:     2,
+			wantFallback: true,
+			wantLastFinH: 100,
+			wantHeadAtAdv: 110,
+		},
+		{
+			name:         "F3 resumes — fallback deactivates",
+			prev:         f3StallState{lastFinalizedH: 100, headAtLastAdvance: 110, fallbackActive: true},
+			minFinH:      150,
+			maxHead:      160,
+			finCount:     2,
+			wantFallback: false,
+			wantLastFinH: 150,
+			wantHeadAtAdv: 160,
+		},
+		{
+			name:         "only 1 node responded — no stall detection",
+			prev:         f3StallState{lastFinalizedH: 100, headAtLastAdvance: 110},
+			minFinH:      100,
+			maxHead:      200,
+			finCount:     1,
+			wantFallback: false,
+			wantLastFinH: 100,
+			wantHeadAtAdv: 110,
+		},
+		{
+			name:         "finalized height regresses (node lagging) — treated as stall",
+			prev:         f3StallState{lastFinalizedH: 100, headAtLastAdvance: 110},
+			minFinH:      90,
+			maxHead:      200,
+			finCount:     2,
+			wantFallback: true,
+			wantLastFinH: 100,
+			wantHeadAtAdv: 110,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := updateF3StallDetection(tt.prev, tt.minFinH, tt.maxHead, tt.finCount)
+
+			if got.fallbackActive != tt.wantFallback {
+				t.Errorf("fallbackActive = %v, want %v", got.fallbackActive, tt.wantFallback)
+			}
+			if got.lastFinalizedH != tt.wantLastFinH {
+				t.Errorf("lastFinalizedH = %d, want %d", got.lastFinalizedH, tt.wantLastFinH)
+			}
+			if got.headAtLastAdvance != tt.wantHeadAtAdv {
+				t.Errorf("headAtLastAdvance = %d, want %d", got.headAtLastAdvance, tt.wantHeadAtAdv)
+			}
+		})
+	}
+}
+
+func TestF3StallDetectionLifecycle(t *testing.T) {
+	state := f3StallState{}
+
+	// Epoch 0-100: F3 advancing normally
+	state = updateF3StallDetection(state, 50, 60, 2)
+	if state.fallbackActive {
+		t.Fatal("should not be active during normal F3")
+	}
+
+	state = updateF3StallDetection(state, 80, 90, 2)
+	if state.fallbackActive {
+		t.Fatal("should not be active during normal F3")
+	}
+
+	// F3 stalls at height 100 (e.g. miner slash broke quorum)
+	state = updateF3StallDetection(state, 100, 110, 2)
+	stalledState := state
+
+	// Chain keeps growing but F3 is stuck
+	state = updateF3StallDetection(state, 100, 120, 2)
+	if state.fallbackActive {
+		t.Fatal("should not activate within grace period")
+	}
+
+	state = updateF3StallDetection(state, 100, 140, 2)
+	if state.fallbackActive {
+		t.Fatal("should not activate within grace period")
+	}
+
+	// Head reaches 110 + 50 = 160 → grace period exceeded
+	state = updateF3StallDetection(state, 100, stalledState.headAtLastAdvance+f3StallGraceEpochs, 2)
+	if !state.fallbackActive {
+		t.Fatal("should activate after grace period")
+	}
+
+	// Stays active while stalled
+	state = updateF3StallDetection(state, 100, 200, 2)
+	if !state.fallbackActive {
+		t.Fatal("should stay active while F3 stalled")
+	}
+
+	// F3 resumes (e.g. power redistributed, quorum restored)
+	state = updateF3StallDetection(state, 150, 160, 2)
+	if state.fallbackActive {
+		t.Fatal("should deactivate when F3 resumes")
+	}
+	if state.lastFinalizedH != 150 {
+		t.Fatalf("lastFinalizedH = %d, want 150", state.lastFinalizedH)
+	}
+}


### PR DESCRIPTION
## Summary
- Adds F3 stall detection to `getFinalizedSnapshots()` — when F3 finalized height stops advancing while chain head grows (e.g. miner slash broke quorum), falls back to EC-based finality (`head - 30 epochs`)
- Automatically deactivates fallback when F3 resumes finalizing
- Enables running `DoPowerAwareSlash` + `DoReorgChaos` together in nightly without blinding consensus vectors — tests the real F3 quorum loss scenario from the recent mainnet incident
- Pure state machine extracted into `updateF3StallDetection()` with full unit test coverage (9 table-driven + 1 lifecycle test)

## Test plan
- [x] Unit tests pass: `go test ./cmd/stress-engine/ -run TestF3Stall -v` (11/11)
- [ ] Local devnet: run nightly profile, observe `[power-slash]` + `[finalized] F3 stall detected` logs
- [ ] Verify consensus vectors continue checking new heights after fallback activates
- [ ] Verify `[finalized] F3 resumed` log if quorum is restored