### PR TITLE
fix: remove dead-by-design Sometimes assertion in n-split verification

### DIFF
--- a/workload/cmd/stress-engine/nsplit_vectors.go
+++ b/workload/cmd/stress-engine/nsplit_vectors.go
@@ -1023,8 +1023,13 @@ func verifyOutcome(refNode api.FullNode, ar *attackResult, cycleNum int,
 			log.Printf("[consensus-test] EC resolved fork — honest majority won")
 			assert.Sometimes(true, "EC resolved fork correctly", details)
 		} else {
+			// landed == 0: no assertion fires here. The "double-spend
+			// succeeded under EC-only" and "EC resolved fork correctly"
+			// Sometimes assertions above already cover the positive cases.
+			// A separate assertion in this branch can never satisfy
+			// `Sometimes` (the condition `landed > 0` is by definition
+			// false here), so it would be dead-by-design noise.
 			log.Printf("[consensus-test] Neither tx landed under EC-vulnerable partition")
-			assert.Sometimes(landed > 0, "Attack landed at least one tx under EC-vulnerable partition", details)
 		}
 	}
 


### PR DESCRIPTION
## Summary

Remove a `Sometimes` assertion in `verifyOutcome` that is structurally unable to pass.

The assertion `"Attack landed at least one tx under EC-vulnerable partition"` (`nsplit_vectors.go:1027`) was only ever fired from the `landed == 0` branch, where the condition `landed > 0` is — by definition — always `false`. A `Sometimes` assertion that's only ever evaluated false can never pass, so this fires as a 0-pass / N-fail finding on every consensus run.

The positive-outcome cases already fire their own `Sometimes` assertions:
- `landed == 2` → `"<attack> succeeded under EC-only"`
- `landed == 1` → `"EC resolved fork correctly"`

so the absence-of-pass on those is sufficient signal that no tx landed. No coverage is lost.

## Evidence

Recent consensus runs flagging this as a "new" finding:
- 2026-04-29 01:36 UTC: 2 fails / 0 pass (`50/50-bisection` strategy)

Decoded payload from one example:
```
strategy: "50/50-bisection", adversary_pct: 50, attack: "double-spend",
ec_vulnerable: true, f3_has_quorum: false,
total_landed: 0, a_landed: false, b_landed: false
```
Both attack txs failed to land — exactly the `landed == 0` branch.

## Test plan

- [x] `go build ./cmd/stress-engine` clean
- [x] `go vet ./cmd/stress-engine` clean
- [ ] Next consensus run no longer reports this property as failing

🤖 Generated with [Claude Code](https://claude.com/claude-code)