### PR TITLE
add forest profile to forest0

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -131,7 +131,7 @@ services:
     image: forest:latest
     container_name: forest0
     entrypoint: [ "./scripts/start-forest.sh", "0" ]
-    profiles: [ full ]
+    profiles: [ full, forest ]
 
   forest1:
     <<: [ *filecoin_service, *needs_lotus0_healthy ]


### PR DESCRIPTION
Adds forest profile so that we can use this profile for "drand" and "fip" setups.
Need to revist env.fip to ensure it doesn't call extra miners resulting into issues.