### PR TITLE
Support for less lotus nodes

### DIFF
--- a/env.drand
+++ b/env.drand
@@ -121,6 +121,9 @@ FOREST_F3_SIDECAR_FFI_ENABLED=1
 FOREST_0_DATA_DIR=/forest0
 FOREST_0_F3_SIDECAR_RPC_ENDPOINT=forest0:${F3_RPC_PORT}
 
+# Forest 1 (not running in this profile, but needed for shared volume template)
+FOREST_1_DATA_DIR=/forest1
+
 # ----------------------------- CURIO -----------------------------
 CURIO_DATA_DIR=/curio
 LOTUS_PATH=${LOTUS_0_PATH}

--- a/env.fip
+++ b/env.fip
@@ -6,11 +6,11 @@
 # Heavy state audit, receipt audit, and actor migration weights.
 
 # ----------------------------- SCALE -----------------------------
-NUM_LOTUS_CLIENTS=4
-NUM_LOTUS_MINERS=4
-SECTORS_PER_MINER="4,3,2,1"
-NUM_FOREST_CLIENTS=2
-STRESS_NODES=lotus0,lotus1,lotus2,lotus3,forest0,forest1
+NUM_LOTUS_CLIENTS=2
+NUM_LOTUS_MINERS=2
+SECTORS_PER_MINER="4,3"
+NUM_FOREST_CLIENTS=1
+STRESS_NODES=lotus0,lotus1,forest0
 
 # FIP-0115 spec: >=6000 txs from >=2000 distinct accounts within 60s.
 # Genesis init actor caps Accounts at MaxAccounts=900 (chain/gen/genesis


### PR DESCRIPTION
Without the FOREST_1_DATA_DIR var `drand` run is failing. As it is part of template.
Additionally added changes for env.fip for lowering miners so that connections dont error out with reduced nodes.