### PR TITLE
fix: plumb STRESS_WEIGHT_FIP0115 through docker-compose to workload

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -206,6 +206,8 @@ services:
       - STRESS_WEIGHT_CROSS_IMPL_COMPUTE=${STRESS_WEIGHT_CROSS_IMPL_COMPUTE:-2}
       - STRESS_WEIGHT_DEEP_ACTOR_STATE=${STRESS_WEIGHT_DEEP_ACTOR_STATE:-1}
       - STRESS_WEIGHT_CROSS_IMPL_ETH_CALL=${STRESS_WEIGHT_CROSS_IMPL_ETH_CALL:-1}
+      # FIP-specific post-activation probes
+      - STRESS_WEIGHT_FIP0115=${STRESS_WEIGHT_FIP0115:-0}
       # --- FOC (Filecoin On-Chain Cloud) vectors ---
       # All FOC vectors require the `foc` compose profile to be active.
       # The lifecycle state machine must reach "Ready" before steady-state


### PR DESCRIPTION
## Summary

The standalone `DoFIP0115BaseFeeResponse` deck vector (added in `fd0cd37`) was registered with default weight 0 and intended to be enabled via env.fip's `STRESS_WEIGHT_FIP0115=1`, but `docker-compose.yaml`'s workload service env block didn't forward that variable. So the workload container always saw the Go-code default of 0 and the deck never picked the vector.

## Evidence

5 consecutive daily fip runs (Apr 30 → May 4) showed `FIP-0115*` properties absent from passed / failed / unfound — meaning `DoFIP0115BaseFeeResponse` was never invoked once across ~62.5h of wall-clock testing. The four `FIP0115_*` data variables were already plumbed (`MSG_COUNT`, `DURATION_SEC`, `PREMIUM_ATTO`, `PRE_LEAD_EPOCHS`); only the deck-weight var was missing.

## Fix

One-line addition to the workload service env block in `docker-compose.yaml`:

```yaml
- STRESS_WEIGHT_FIP0115=${STRESS_WEIGHT_FIP0115:-0}
```

Default 0 so non-fip profiles are unaffected. env.fip already sets it to 1.

## Test plan

- [x] `docker compose config --services` parses OK
- [ ] Next fip cron run shows `FIP-0115 flood completed` Reachable hit and `FIP-0115: base fee rises under congestion (post-NV28)` Sometimes assertion firing

🤖 Generated with [Claude Code](https://claude.com/claude-code)